### PR TITLE
Bump KLambda *port* to match release version 0.45

### DIFF
--- a/src/version.scm
+++ b/src/version.scm
@@ -1,2 +1,1 @@
-(kl:set '*port* "0.44")
-
+(kl:set '*port* "0.45")


### PR DESCRIPTION
Looks like this was accidentally omitted from the 0.45 release.