### PR TITLE
Add native AOT compilation, modules, and app builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,18 +9,19 @@ on:
 jobs:
   build:
     name: Build and test
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     env:
       CHEZ_SCHEME_VERSION: '10.3.0'
     strategy:
+      fail-fast: false
       matrix:
-        os: [macos, ubuntu, windows]
+        os: [macos-latest, ubuntu-latest, windows-2022]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Chez cache
         id: shen-scheme-chez10-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: _build/chez
           key: ${{ matrix.os }}-chez-${{ env.CHEZ_SCHEME_VERSION }}
@@ -28,7 +29,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y uuid-dev
-        if: runner.os == 'linux'
+        if: runner.os == 'Linux'
       - name: Build Chez
         run: make chez_kernel
       - name: Build and test
@@ -39,3 +40,10 @@ jobs:
           make precompile-with-prebuilt
           make csversion=${{ env.CHEZ_SCHEME_VERSION }}
           make test
+      - name: Test clean parallel build
+        run: make test-clean-parallel-build
+      - name: Test runtime artifact recovery
+        run: make test-runtime-artifact-recovery
+      - name: Test external runtime modes
+        if: runner.os == 'Linux'
+        run: make test-external-runtime

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@
 /shen-sources
 /shen-chez.scm
 /shen-scheme.scm
+/shen-scheme-runtime.ss
 /shen-scheme
-/shen.boot
 *.o
 /_build
 /_dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Native AOT compilation for Shen source files and declared modules, including
+  top-level `defprolog` and `package` forms and arbitrary top-level Shen
+  expression effects.
+- Compatible and sealed compilation modes, build profiles, dependency
+  resolution, standalone app builds, and whole-program optimization support.
+- Port-style and realistic benchmark suites comparing dynamic loading,
+  compatible and sealed native compilation, and native app builds.
+- Runnable native-compilation examples and a guide covering source files,
+  packages, modules, applications, deployment, and embedding.
+
+### Changed
+
+- Compiler arity registrations are generated from compiled definitions instead
+  of maintaining a parallel manual list.
+- Shen/Scheme now starts from the stock Chez boot files and loads a combined
+  runtime and launcher object instead of generating a custom `shen.boot`.
+  `SHEN_SCHEME_RUNTIME=petite` selects a compiler-free runtime that can still
+  load precompiled native artifacts.
+
+### Removed
+
+- The generated `shen.boot` artifact and the `SHEN_SCHEME_BOOT` override.
+  `SHEN_SCHEME_HOME` now selects a complete, internally consistent runtime
+  artifact set.
+
 ## [0.45] - 2026-04-19
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,29 @@ compiled_dir ?= compiled
 exe ?= $(build_dir)/bin/shen-scheme$(binext)
 prefix ?= /usr/local
 home_path ?= "$(prefix)/lib/shen-scheme"
-bootfile = $(build_dir)/lib/shen-scheme/shen.boot
+SHEN_SCHEME_OPTIMIZE_LEVEL ?= 2
+SHEN_SCHEME_DEBUG_LEVEL ?= 0
+SHEN_SCHEME_INSPECTOR ?= false
+SHEN_SCHEME_SOURCE_INFO ?= false
 
-precompiled_dir = $(build_dir)$(S)shen-scheme-v0.26-src
+petite_bootfile = $(build_dir)/lib/shen-scheme/petite.boot
+scheme_bootfile = $(build_dir)/lib/shen-scheme/scheme.boot
+runtime_src = shen-scheme-runtime.ss
+runtime_obj = $(build_dir)/lib/shen-scheme/shen-scheme/runtime.so
+runtime_main_obj = $(build_dir)/obj/shen-scheme-main.so
+runtime_lib_obj = $(build_dir)/obj/shen-scheme/runtime.so
+runtime_config = o$(SHEN_SCHEME_OPTIMIZE_LEVEL)-d$(SHEN_SCHEME_DEBUG_LEVEL)-i$(SHEN_SCHEME_INSPECTOR)-s$(SHEN_SCHEME_SOURCE_INFO)
+runtime_stamp_prefix = $(build_dir)/obj/shen-scheme-runtime
+runtime_stamp = $(runtime_stamp_prefix)-$(runtime_config).stamp
+runtime_stamps = $(runtime_stamp_prefix)*.stamp
+runtime_artifacts = $(petite_bootfile) $(scheme_bootfile) $(runtime_obj)
+runtime_inputs = $(psboot) $(csboot) shen-scheme.scm $(runtime_src) src/* \
+	$(compiled_dir)/*.scm scripts/build-runtime.ss
+runtime_artifact_dirs = mkdir -p $(build_dir)/obj/shen-scheme $(build_dir)/lib/shen-scheme/shen-scheme
+runtime_artifact_build = "$(scmexe)" -q -b "$(psboot)" -b "$(csboot)" --script scripts/build-runtime.ss \
+	shen-scheme.scm "$(runtime_main_obj)" "$(runtime_src)" "$(runtime_lib_obj)" "$(runtime_obj)" \
+	"$(SHEN_SCHEME_OPTIMIZE_LEVEL)" "$(SHEN_SCHEME_DEBUG_LEVEL)" \
+	"$(SHEN_SCHEME_INSPECTOR)" "$(SHEN_SCHEME_SOURCE_INFO)"
 
 git_tag ?= $(shell git tag -l --contains HEAD 2> /dev/null)
 ifeq ("$(git_tag)","")
@@ -96,7 +116,7 @@ endif
 
 .DEFAULT: all
 .PHONY: all
-all: $(exe) $(bootfile)
+all: $(exe) $(runtime_artifacts)
 
 $(csdir):
 	echo "Downloading and uncompressing Chez..."
@@ -110,6 +130,11 @@ ifeq ($(os), windows)
 else
 	cd $(csdir) && ./configure --threads --disable-curses --disable-iconv --disable-x11 && make
 endif
+
+# The Chez build creates its kernel and stock boot files together. Declaring
+# that relationship keeps fresh parallel builds from racing the boot copies.
+$(psboot) $(csboot): | $(cskernel)
+	test -f "$@"
 
 .PHONY: chez_kernel
 chez_kernel: $(cskernel)
@@ -133,9 +158,25 @@ else
 	$(CC) -c -o $@ $< -I$(csbootpath) -I./lib -Wall -Wextra -pedantic $(CFLAGS)
 endif
 
-$(bootfile): $(psboot) $(csboot) shen-scheme.scm src/* $(compiled_dir)/*.scm
+$(petite_bootfile): $(psboot)
 	mkdir -p $(build_dir)/lib/shen-scheme
-	echo '(make-boot-file "$(bootfile)" (list)  "$(psboot)" "$(csboot)" "shen-scheme.scm")' | "$(scmexe)" -q -b "$(psboot)" -b "$(csboot)"
+	cp "$<" "$@"
+
+$(scheme_bootfile): $(csboot)
+	mkdir -p $(build_dir)/lib/shen-scheme
+	cp "$<" "$@"
+
+# Keeping only the active configuration stamp makes changing any build option,
+# including changing it back, rebuild the runtime.
+$(runtime_stamp): $(runtime_inputs)
+	$(runtime_artifact_dirs)
+	$(RM) $(runtime_stamps)
+	$(runtime_artifact_build)
+	touch "$@"
+
+$(runtime_obj): | $(runtime_stamp)
+	@test -f "$@" || $(runtime_artifact_dirs)
+	@test -f "$@" || $(runtime_artifact_build)
 
 .PHONY: fetch-kernel
 fetch-kernel:
@@ -153,44 +194,33 @@ fetch-prebuilt:
 precompile-with-prebuilt:
 	$(build_dir)$(S)shen-scheme-v0.26-$(os)-bin$(S)bin$(S)shen-scheme$(binext) script scripts/do-build.shen > /dev/null
 
-$(precompiled_dir):
-	mkdir -p $(build_dir)
-	curl -LO 'https://github.com/tizoc/shen-scheme/releases/download/v0.26/shen-scheme-v0.26-src.tar.gz'
-	tar xzf shen-scheme-v0.26-src.tar.gz -C $(build_dir)
-	rm -f $(precompiled_dir)$(S)Makefile
-	cp Makefile $(precompiled_dir)$(S)Makefile
-
 .PHONY: precompile
 precompile:
 	$(SHEN) script scripts/do-build.shen > /dev/null
 
-.PHONY: build-precompiled
-build-precompiled: $(precompiled_dir) $(cskernel)
-	mkdir -p $(precompiled_dir)$(S)_build
-	cp -a $(chez_build_dir) $(precompiled_dir)$(S)$(chez_build_dir)
-	cd $(precompiled_dir); make csversion=$(csversion)
-
 .PHONY: test-shen
-test-shen: $(exe) $(bootfile)
+test-shen: $(exe) $(runtime_artifacts)
 	./$(exe) script scripts/run-shen-tests.shen
 
 .PHONY: test-compiler
-test-compiler: $(exe) $(bootfile)
+test-compiler: $(exe) $(runtime_artifacts)
 	./$(exe) script scripts/run-compiler-tests.shen
 
 .PHONY: test
 test: test-shen test-compiler
 
 .PHONY: run
-run: $(exe) $(bootfile)
+run: $(exe) $(runtime_artifacts)
 	./$(exe)
 
 .PHONY: install
-install: $(exe) $(bootfile)
+install: $(exe) $(runtime_artifacts)
 	mkdir -p $(DESTDIR)$(prefix)/bin
-	mkdir -p $(DESTDIR)$(home_path)
+	mkdir -p $(DESTDIR)$(home_path)/shen-scheme
 	install -m 0755 $(exe) $(DESTDIR)$(prefix)/bin
-	install -m 0644 $(bootfile) $(DESTDIR)$(home_path)/
+	install -m 0644 $(petite_bootfile) $(DESTDIR)$(home_path)/
+	install -m 0644 $(scheme_bootfile) $(DESTDIR)$(home_path)/
+	install -m 0644 $(runtime_obj) $(DESTDIR)$(home_path)/shen-scheme/
 
 .PHONY: source-release
 source-release:
@@ -198,19 +228,22 @@ source-release:
 	git archive --format=tar --prefix="$(archive_name)/" $(git_tag) | (cd _dist && tar xf -)
 	cp $(compiled_dir)/*.scm "_dist/$(archive_name)/compiled/"
 	cp shen-scheme.scm "_dist/$(archive_name)/shen-scheme.scm"
+	cp $(runtime_src) "_dist/$(archive_name)/$(runtime_src)"
 	rm -rf "_dist/$(archive_name)/".git*
 	rm "_dist/$(archive_name)/"*/.gitignore
 	cd _dist; tar cvzf "$(archive_name).tar.gz" "$(archive_name)/";	rm -rf "$(archive_name)/"
 	echo "Generated tarball for tag $(git_tag) as _dist/$(archive_name).tar.gz"
 
 .PHONY: binary-release
-binary-release: $(exe) $(bootfile)
+binary-release: $(exe) $(runtime_artifacts)
 	mkdir -p "_dist/shen-scheme-$(git_tag)-$(os)-bin"
 	mkdir -p "_dist/shen-scheme-$(git_tag)-$(os)-bin/bin"
-	mkdir -p "_dist/shen-scheme-$(git_tag)-$(os)-bin/lib/shen-scheme"
+	mkdir -p "_dist/shen-scheme-$(git_tag)-$(os)-bin/lib/shen-scheme/shen-scheme"
 	mkdir -p "_dist/shen-scheme-$(git_tag)-$(os)-bin/chez-legal"
 	cp $(exe) "_dist/shen-scheme-$(git_tag)-$(os)-bin/bin"
-	cp $(bootfile) "_dist/shen-scheme-$(git_tag)-$(os)-bin/lib/shen-scheme"
+	cp $(petite_bootfile) "_dist/shen-scheme-$(git_tag)-$(os)-bin/lib/shen-scheme"
+	cp $(scheme_bootfile) "_dist/shen-scheme-$(git_tag)-$(os)-bin/lib/shen-scheme"
+	cp $(runtime_obj) "_dist/shen-scheme-$(git_tag)-$(os)-bin/lib/shen-scheme/shen-scheme"
 	cp README.md "_dist/shen-scheme-$(git_tag)-$(os)-bin/README.txt"
 	cp LICENSE "_dist/shen-scheme-$(git_tag)-$(os)-bin/LICENSE.txt"
 	cp $(cslicense) "_dist/shen-scheme-$(git_tag)-$(os)-bin/chez-legal/LICENSE.txt"
@@ -219,4 +252,5 @@ binary-release: $(exe) $(bootfile)
 
 .PHONY: clean
 clean:
-	rm -f $(exe) $(bootfile) *.o *.obj
+	rm -f $(exe) $(petite_bootfile) $(scheme_bootfile) $(runtime_obj) \
+		$(runtime_main_obj) $(runtime_lib_obj) $(runtime_stamps) *.o *.obj

--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,28 @@ test-native: $(exe) $(runtime_artifacts)
 	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-app-profile-wpo.so\")" -e "(if (= (value *native-app-init-events*) [1 12]) ok (error \"native CLI WPO profile app initializer order failed\"))" -e "(if (= (native-app-main 31) 42) ok (error \"native CLI WPO profile app build failed\"))" -e "(if (= (native-app-length [1 2 3]) 3) ok (error \"native CLI WPO profile app runtime call failed\"))" -e "(if (= (native-app-absvector?) true) ok (error \"native CLI WPO profile app absvector failed\"))" -e "(if (= (native-app-list-equal?) true) ok (error \"native CLI WPO profile app generic equality failed\"))" -e "(if (= (native-app-sysfunc?) true) ok (error \"native CLI WPO profile app static global failed\"))"
 	./$(exe) load-compiled _build/native-tests/cli-simple.so
 
+.PHONY: test-native-examples
+test-native-examples: $(exe) $(runtime_artifacts)
+	mkdir -p _build/native-examples/modules
+	cp examples/native/modules/native-example.core.shenmod _build/native-examples/modules/
+	cp examples/native/modules/native-example.app.shenmod _build/native-examples/modules/
+	./$(exe) compile examples/native/single-file.shen -o _build/native-examples/single-file.so
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-examples/single-file.so\")" -e "(if (= (answer 5) 26) ok (error \"native single-file example failed\"))"
+	./$(exe) compile examples/native/binding.shen -o _build/native-examples/compatible.so
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-examples/compatible.so\")" -e "(load \"examples/native/binding-update.shen\")" -e "(if (= (call-helper 1) 101) ok (error \"native compatible example failed\"))"
+	./$(exe) compile examples/native/binding.shen --mode sealed -o _build/native-examples/sealed.so
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-examples/sealed.so\")" -e "(load \"examples/native/binding-update.shen\")" -e "(if (= (call-helper 1) 2) ok (error \"native sealed example failed\"))"
+	./$(exe) compile examples/native/package-effects.shen -o _build/native-examples/package-effects.so
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-examples/package-effects.so\")" -e "(if (= (effect-events) [\"inside-before-definition\" \"after-definition\"]) ok (error \"native package effects example failed\"))"
+	./$(exe) compile-module _build/native-examples/modules/native-example.core.shenmod -o _build/native-examples/modules/native-example.core.so
+	./$(exe) compile-module _build/native-examples/modules/native-example.app.shenmod --module-dir _build/native-examples/modules -o _build/native-examples/modules/native-example.app.so
+	./$(exe) eval -q -e "(shen-scheme.load-module \"_build/native-examples/modules/native-example.app.shenmod\" \"_build/native-examples/modules\")" -e "(if (= (run-example 32) 42) ok (error \"native module graph example failed\"))" -e "(if (= (module-events) [42]) ok (error \"native module initializer example failed\"))"
+	./$(exe) build-module-app _build/native-examples/modules/native-example.app.shenmod --module-dir _build/native-examples/modules -o _build/native-examples/app.so
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-examples/app.so\")" -e "(if (= (run-example 32) 42) ok (error \"native module app example failed\"))" -e "(if (= (module-events) [42]) ok (error \"native module app initializer example failed\"))"
+	./$(exe) build-module-app _build/native-examples/modules/native-example.app.shenmod --module-dir _build/native-examples/modules -o _build/native-examples/app-wpo.so --wpo
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-examples/app-wpo.so\")" -e "(if (= (run-example 32) 42) ok (error \"native WPO module app example failed\"))"
+	SHEN_SCHEME_RUNTIME=petite ./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-examples/single-file.so\")" -e "(if (= (answer 5) 26) ok (error \"native full-to-Petite example failed\"))"
+
 .PHONY: bench-native
 bench-native: $(exe) $(runtime_artifacts)
 	mkdir -p _build/native-bench
@@ -297,7 +319,7 @@ test-clean-parallel-build: chez_kernel
 	./$(exe) --version
 
 .PHONY: test
-test: test-shen test-compiler test-native
+test: test-shen test-compiler test-native test-native-examples
 
 .PHONY: test-external-runtime
 test-external-runtime: $(exe) $(runtime_artifacts)
@@ -346,6 +368,8 @@ source-release:
 binary-release: $(exe) $(runtime_artifacts)
 	mkdir -p "_dist/shen-scheme-$(git_tag)-$(os)-bin"
 	mkdir -p "_dist/shen-scheme-$(git_tag)-$(os)-bin/bin"
+	mkdir -p "_dist/shen-scheme-$(git_tag)-$(os)-bin/docs"
+	mkdir -p "_dist/shen-scheme-$(git_tag)-$(os)-bin/examples"
 	mkdir -p "_dist/shen-scheme-$(git_tag)-$(os)-bin/lib/shen-scheme/shen-scheme"
 	mkdir -p "_dist/shen-scheme-$(git_tag)-$(os)-bin/chez-legal"
 	cp $(exe) "_dist/shen-scheme-$(git_tag)-$(os)-bin/bin"
@@ -353,6 +377,8 @@ binary-release: $(exe) $(runtime_artifacts)
 	cp $(scheme_bootfile) "_dist/shen-scheme-$(git_tag)-$(os)-bin/lib/shen-scheme"
 	cp $(runtime_obj) "_dist/shen-scheme-$(git_tag)-$(os)-bin/lib/shen-scheme/shen-scheme"
 	cp README.md "_dist/shen-scheme-$(git_tag)-$(os)-bin/README.txt"
+	cp docs/native-compilation.md "_dist/shen-scheme-$(git_tag)-$(os)-bin/docs"
+	cp -R examples/native "_dist/shen-scheme-$(git_tag)-$(os)-bin/examples"
 	cp LICENSE "_dist/shen-scheme-$(git_tag)-$(os)-bin/LICENSE.txt"
 	cp $(cslicense) "_dist/shen-scheme-$(git_tag)-$(os)-bin/chez-legal/LICENSE.txt"
 	cp $(cscopyright) "_dist/shen-scheme-$(git_tag)-$(os)-bin/chez-legal/NOTICE.txt"

--- a/Makefile
+++ b/Makefile
@@ -205,9 +205,92 @@ test-shen: $(exe) $(runtime_artifacts)
 .PHONY: test-compiler
 test-compiler: $(exe) $(runtime_artifacts)
 	./$(exe) script scripts/run-compiler-tests.shen
+	./$(exe) script scripts/run-build-library-tests.shen
+	"$(scmexe)" -q -b "$(psboot)" -b "$(csboot)" \
+		--script scripts/check-build-library.ss
+
+.PHONY: test-native
+test-native: $(exe) $(runtime_artifacts)
+	mkdir -p _build/native-tests
+	./$(exe) script scripts/run-native-tests.shen
+	./$(exe) eval -q -e "(shen-scheme.delete-file-if-exists \"_build/native-tests/cli-direct.so.scm\")"
+	./$(exe) compile tests/native/simple.shen -o _build/native-tests/cli-direct.so
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-direct.so\")" -e "(if (= (native-test-map-inc (cons 4 (cons 5 []))) [5 6]) ok (error \"native CLI direct compile failed\"))" -e "(if (= (shen-scheme.file-exists? \"_build/native-tests/cli-direct.so.scm\") false) ok (error \"native CLI direct compile emitted scheme\"))"
+	./$(exe) compile tests/native/simple.shen --profile debug -o _build/native-tests/cli-profile-debug.so
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-profile-debug.so\")" -e "(if (= (native-test-map-inc (cons 4 (cons 5 []))) [5 6]) ok (error \"native CLI debug profile compile failed\"))"
+	./$(exe) compile tests/native/simple.shen -o _build/native-tests/cli-simple.so --emit-scheme _build/native-tests/cli-simple.scm
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-simple.so\")" -e "(if (= (native-test-map-inc (cons 4 (cons 5 []))) [5 6]) ok (error \"native CLI compile failed\"))"
+	./$(exe) compile tests/native/redefinition-sealed.shen -o _build/native-tests/cli-sealed.so --emit-scheme _build/native-tests/cli-sealed.scm --mode sealed
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-sealed.so\")" -e "(if (= (native-sealed-main 5) 6) ok (error \"native CLI sealed compile failed\"))"
+	./$(exe) compile tests/native/package-effects.shen -o _build/native-tests/cli-package-effects.so
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-package-effects.so\")" -e "(if (= (native-package-main 5) 12) ok (error \"native CLI package call failed\"))" -e "(if (= (native-package-state) [41 2]) ok (error \"native CLI package effect order failed\"))" -e "(if (package? native.test.pkg) ok (error \"native CLI package registration failed\"))" -e "(if (element? native-package-main (external native.test.pkg)) ok (error \"native CLI package external registration failed\"))" -e "(if (element? native.test.pkg.helper (internal native.test.pkg)) ok (error \"native CLI package internal registration failed\"))" -e "(if (not (= [] (assoc native.test.pkg.helper (value shen.*sigf*)))) ok (error \"native CLI package declaration failed\"))"
+	./$(exe) compile-module tests/native/package-effects.shenmod -o _build/native-tests/cli-package-effects-module.so
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-package-effects-module.so\")" -e "(if (= (value *native-package-events*) [41 2]) ok (error \"native CLI package module effects failed\"))" -e "(if (package? native.test.pkg) ok (error \"native CLI package module registration failed\"))" -e "(if (= unavailable (trap-error (native-package-main 5) (/. E unavailable))) ok (error \"native CLI package module metadata policy failed\"))"
+	./$(exe) compile-module _build/native-tests/module-decl.shenmod -o _build/native-tests/cli-module.so --emit-scheme _build/native-tests/cli-module.scm
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-module.so\")" -e "(if (= (native-module-main 5) 42) ok (error \"native CLI module declaration compile failed\"))"
+	./$(exe) compile-module _build/native-tests/module-declared.shenmod -o _build/native-tests/cli-module-declared.so
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-module-declared.so\")" -e "(if (= (native-module-declared 41) 42) ok (error \"native CLI module declared call failed\"))" -e "(if (not (= [] (assoc native-module-declared (value shen.*sigf*)))) ok (error \"native CLI module explicit declare metadata failed\"))"
+	./$(exe) compile-module _build/native-tests/module-runtime-only-declared.shenmod -o _build/native-tests/cli-module-runtime-only-declared.so
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-module-runtime-only-declared.so\")" -e "(if (= (native-module-runtime-only-declared 41) 42) ok (error \"native CLI module runtime-only declared call failed\"))" -e "(if (= [] (assoc native-module-runtime-only-declared (value shen.*sigf*))) ok (error \"native CLI module runtime-only declared metadata leaked\"))"
+	./$(exe) compile-module _build/native-tests/module-macro.shenmod -o _build/native-tests/cli-module-macro.so
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-module-macro.so\")" -e "(load \"_build/native-tests/module-macro-user.shen\")" -e "(if (= (native-module-macro-user 21) 42) ok (error \"native CLI module macro metadata failed\"))"
+	./$(exe) compile-module _build/native-tests/module-synonym.shenmod -o _build/native-tests/cli-module-synonym.so
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-module-synonym.so\")" -e "(tc +)" -e "(load \"_build/native-tests/module-synonym-user.shen\")" -e "(tc -)" -e "(if (= (native-module-synonym-user 41) 42) ok (error \"native CLI module synonym metadata failed\"))"
+	./$(exe) compile-module _build/native-tests/module-datatype.shenmod -o _build/native-tests/cli-module-datatype.so
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-module-datatype.so\")" -e "(tc +)" -e "(load \"_build/native-tests/module-datatype-user.shen\")" -e "(tc -)" -e "(if (= (native-module-datatype-user 99) 1) ok (error \"native CLI module datatype metadata failed\"))"
+	./$(exe) compile-module _build/native-tests/module-source-kl.shenmod -o _build/native-tests/cli-module-source-kl.so
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-module-source-kl.so\")" -e "(if (= (native-module-source-kl 41) 42) ok (error \"native CLI module source-kl call failed\"))" -e "(if (= defun (hd (ps native-module-source-kl))) ok (error \"native CLI module source-kl ps failed\"))" -e "(if (= native-module-source-kl (hd (tl (ps native-module-source-kl)))) ok (error \"native CLI module source-kl recorded wrong name\"))" -e "(if (element? native-module-source-kl (value shen.*userdefs*)) ok (error \"native CLI module source-kl userdefs failed\"))"
+	./$(exe) compile-module _build/native-tests/module-no-source-kl.shenmod -o _build/native-tests/cli-module-no-source-kl.so
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-module-no-source-kl.so\")" -e "(if (= (native-module-no-source-kl 41) 42) ok (error \"native CLI module no-source-kl call failed\"))" -e "(if (= missing (trap-error (ps native-module-no-source-kl) (/. E missing))) ok (error \"native CLI module no-source-kl leaked ps\"))" -e "(if (not (element? native-module-no-source-kl (value shen.*userdefs*))) ok (error \"native CLI module no-source-kl leaked userdefs\"))"
+	./$(exe) compile-module _build/native-tests/native.test.required.shenmod -o _build/native-tests/native.test.required.so
+	./$(exe) compile-module _build/native-tests/native.test.requirer.shenmod --module-dir _build/native-tests -o _build/native-tests/native.test.requirer.so
+	./$(exe) eval -q -e "(shen-scheme.load-module \"_build/native-tests/native.test.requirer.shenmod\" \"_build/native-tests\")" -e "(if (= (native-module-requirer 32) 42) ok (error \"native CLI module requires failed\"))"
+	./$(exe) load-module _build/native-tests/native.test.requirer.shenmod --module-dir _build/native-tests
+	./$(exe) build-module-app _build/native-tests/native.test.app-main.shenmod --module-dir _build/native-tests -o _build/native-tests/cli-module-app-wpo.so --wpo
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-module-app-wpo.so\")" -e "(if (= (value *native-module-app-init-events*) [10 11]) ok (error \"native CLI module app initializer order failed\"))" -e "(if (= (native-module-app-main 32) 42) ok (error \"native CLI module app failed\"))" -e "(load \"_build/native-tests/module-app-base-updated.shen\")" -e "(if (= (native-module-app-base 1) 1001) ok (error \"native CLI module app dependency redefine failed\"))" -e "(if (= (native-module-app-main 32) 42) ok (error \"native CLI module app lost direct dependency binding\"))"
+	./$(exe) build-app tests/native/app-main.shen --module tests/native/app-lib.shen -o _build/native-tests/cli-app-wpo.so --wpo
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-app-wpo.so\")" -e "(if (= (value *native-app-init-events*) [1 12]) ok (error \"native CLI app initializer order failed\"))" -e "(if (= (native-app-main 31) 42) ok (error \"native CLI app build failed\"))" -e "(if (= (native-app-length [1 2 3]) 3) ok (error \"native CLI app runtime call failed\"))" -e "(if (= (native-app-absvector?) true) ok (error \"native CLI app absvector failed\"))" -e "(if (= (native-app-list-equal?) true) ok (error \"native CLI app generic equality failed\"))" -e "(if (= (native-app-sysfunc?) true) ok (error \"native CLI app static global failed\"))"
+	./$(exe) build-app tests/native/app-main.shen --module tests/native/app-lib.shen -o _build/native-tests/cli-app-profile-wpo.so --profile wpo
+	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-app-profile-wpo.so\")" -e "(if (= (value *native-app-init-events*) [1 12]) ok (error \"native CLI WPO profile app initializer order failed\"))" -e "(if (= (native-app-main 31) 42) ok (error \"native CLI WPO profile app build failed\"))" -e "(if (= (native-app-length [1 2 3]) 3) ok (error \"native CLI WPO profile app runtime call failed\"))" -e "(if (= (native-app-absvector?) true) ok (error \"native CLI WPO profile app absvector failed\"))" -e "(if (= (native-app-list-equal?) true) ok (error \"native CLI WPO profile app generic equality failed\"))" -e "(if (= (native-app-sysfunc?) true) ok (error \"native CLI WPO profile app static global failed\"))"
+	./$(exe) load-compiled _build/native-tests/cli-simple.so
+
+.PHONY: test-runtime-artifact-recovery
+test-runtime-artifact-recovery: $(runtime_artifacts)
+	$(RM) "$(runtime_obj)"
+	$(MAKE) $(runtime_obj)
+	test -f "$(runtime_obj)"
+	test -f "$(runtime_main_obj)"
+	test -f "$(runtime_lib_obj)"
+	"$(scmexe)" -q -b "$(psboot)" -b "$(csboot)" \
+		--script scripts/check-runtime-object.ss \
+		"$(abspath $(build_dir)/lib/shen-scheme)"
+
+.PHONY: test-clean-parallel-build
+test-clean-parallel-build: chez_kernel
+	$(MAKE) clean
+	$(MAKE) -j4 all
+	./$(exe) --version
 
 .PHONY: test
-test: test-shen test-compiler
+test: test-shen test-compiler test-native
+
+.PHONY: test-external-runtime
+test-external-runtime: $(exe) $(runtime_artifacts)
+	mkdir -p _build/external-runtime-tests
+	cmp "$(petite_bootfile)" "$(psboot)"
+	cmp "$(scheme_bootfile)" "$(csboot)"
+	SHEN_SCHEME_HOME="$(abspath $(build_dir)/lib/shen-scheme)" ./$(exe) build-app tests/native/app-main.shen --module tests/native/app-lib.shen -o _build/external-runtime-tests/app-wpo.so --wpo
+	SHEN_SCHEME_HOME="$(abspath $(build_dir)/lib/shen-scheme)" ./$(exe) script scripts/run-external-runtime-tests.shen full _build/external-runtime-tests/app-wpo.so _build/external-runtime-tests/full-compiled.so
+	SHEN_SCHEME_HOME="$(abspath $(build_dir)/lib/shen-scheme)" SHEN_SCHEME_RUNTIME=petite ./$(exe) script scripts/run-external-runtime-tests.shen petite _build/external-runtime-tests/app-wpo.so _build/external-runtime-tests/petite-should-not-compile.so
+ifneq ($(os), windows)
+	mkdir -p "_build/external-runtime-tests/home:literal/shen-scheme"
+	cp "$(petite_bootfile)" "$(scheme_bootfile)" "_build/external-runtime-tests/home:literal/"
+	cp "$(runtime_obj)" "_build/external-runtime-tests/home:literal/shen-scheme/"
+	SHEN_SCHEME_HOME="$(abspath _build/external-runtime-tests/home:literal)" ./$(exe) --version
+endif
+
+.PHONY: test-petite-runtime
+test-petite-runtime: test-external-runtime
 
 .PHONY: run
 run: $(exe) $(runtime_artifacts)

--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,31 @@ test-native: $(exe) $(runtime_artifacts)
 	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-app-profile-wpo.so\")" -e "(if (= (value *native-app-init-events*) [1 12]) ok (error \"native CLI WPO profile app initializer order failed\"))" -e "(if (= (native-app-main 31) 42) ok (error \"native CLI WPO profile app build failed\"))" -e "(if (= (native-app-length [1 2 3]) 3) ok (error \"native CLI WPO profile app runtime call failed\"))" -e "(if (= (native-app-absvector?) true) ok (error \"native CLI WPO profile app absvector failed\"))" -e "(if (= (native-app-list-equal?) true) ok (error \"native CLI WPO profile app generic equality failed\"))" -e "(if (= (native-app-sysfunc?) true) ok (error \"native CLI WPO profile app static global failed\"))"
 	./$(exe) load-compiled _build/native-tests/cli-simple.so
 
+.PHONY: bench-native
+bench-native: $(exe) $(runtime_artifacts)
+	mkdir -p _build/native-bench
+	./$(exe) script scripts/bench-native-sealed.shen
+
+.PHONY: bench-port
+bench-port: $(exe) $(runtime_artifacts)
+	mkdir -p _build/native-bench
+	./$(exe) script benchmarks/run-port-comparison.shen $(PORT_BENCH_ARGS)
+
+.PHONY: bench-port-smoke
+bench-port-smoke: $(exe) $(runtime_artifacts)
+	mkdir -p _build/native-bench
+	./$(exe) script benchmarks/run-port-comparison.shen --quick
+
+.PHONY: bench-realistic
+bench-realistic: $(exe) $(runtime_artifacts)
+	mkdir -p _build/native-bench
+	./$(exe) script benchmarks/run-realistic-comparison.shen $(REALISTIC_BENCH_ARGS)
+
+.PHONY: bench-realistic-smoke
+bench-realistic-smoke: $(exe) $(runtime_artifacts)
+	mkdir -p _build/native-bench
+	./$(exe) script benchmarks/run-realistic-comparison.shen --quick
+
 .PHONY: test-runtime-artifact-recovery
 test-runtime-artifact-recovery: $(runtime_artifacts)
 	$(RM) "$(runtime_obj)"

--- a/README.md
+++ b/README.md
@@ -1,30 +1,28 @@
+# Shen/Scheme
+
 [![Shen Version](https://img.shields.io/badge/shen-41.2-blue.svg)](https://github.com/Shen-Language)
 [![build](https://github.com/tizoc/shen-scheme/workflows/build/badge.svg)](https://github.com/tizoc/shen-scheme/actions?query=workflow%3Abuild)
-
-Shen/Scheme, a Scheme port of the Shen language
-====================================================
 
 * [Shen](https://shen-language.github.io/)
 * [chez-scheme](https://cisco.github.io/ChezScheme)
 * [shen-scheme](https://github.com/tizoc/shen-scheme)
 
-Shen is a portable functional programming language by [Mark Tarver](http://marktarver.com) that offers
+Shen/Scheme is a port of the Shen language that runs on Scheme. The currently
+supported backend is [Chez Scheme](https://cisco.github.io/ChezScheme).
+
+Shen is a portable functional programming language by
+[Mark Tarver](http://marktarver.com) that offers:
 
 - pattern matching,
-- λ calculus consistency,
+- lambda calculus consistency,
 - macros,
 - optional lazy evaluation,
 - static type checking,
 - an integrated fully functional Prolog,
 - and an inbuilt compiler-compiler.
 
-shen-scheme is a port of the Shen language that runs on top of Sheme implementations.
-
-Right now the following implementations are supported:
-
-* [chez-scheme](https://cisco.github.io/ChezScheme)
-
-The following implementations were supported in version 0.15, but are not supported since version 0.16. Support may be added back in future releases.
+Older Shen/Scheme releases supported additional Scheme implementations. Since
+version 0.16, the maintained backend is Chez Scheme.
 
 * [chibi-scheme](http://synthcode.com/wiki/chibi-scheme)
 * [gauche](http://practical-scheme.net/gauche/)
@@ -32,25 +30,15 @@ The following implementations were supported in version 0.15, but are not suppor
 Binaries
 --------
 
-Starting with version 0.18, binaries are provided for Windows, Linux and OSX. See [releases](https://github.com/tizoc/shen-scheme/releases).
+Starting with version 0.18, binaries are provided for Windows, Linux, and macOS.
+See [releases](https://github.com/tizoc/shen-scheme/releases).
 
-OSX users can also use homebrew to install Shen/Scheme:
+Nix users can use the community-maintained package at
+https://github.com/hakujin/nix-shen-scheme. With Nix installed, you can drop
+into a working Shen/Scheme via:
 
-```
-$ brew install Shen-Language/homebrew-shen/shen-scheme
-==> Installing shen-language/shen/shen-scheme
-==> Downloading https://github.com/tizoc/shen-scheme/releases/download/0.17/shen-scheme-0.17-src.tar.gz
-Already downloaded: /Users/bruno/Library/Caches/Homebrew/shen-scheme-0.17.tar.gz
-==> Downloading https://github.com/cisco/ChezScheme/archive/v9.5.tar.gz
-Already downloaded: /Users/bruno/Library/Caches/Homebrew/shen-scheme--chezscheme-9.5.tar.gz
-==> make install prefix=/usr/local/Cellar/shen-scheme/0.17
-  /usr/local/Cellar/shen-scheme/0.17: 7 files, 2.8MB, built in 1 minute 16 seconds
-```
-
-Nix users can use a community-maintained package at https://github.com/hakujin/nix-shen-scheme. The maintainer also keeps the nixpkgs version of the SBCL port of Shen up to date. With Nix installed, you can drop into a working Shen/Scheme via:
-
-```
-$ nix run github:hakujin/nix-shen-scheme/master#shen-scheme
+```sh
+nix run github:hakujin/nix-shen-scheme/master#shen-scheme
 ```
 
 Building
@@ -60,57 +48,169 @@ Building
 
 > **IMPORTANT:** Download the release asset named `shen-scheme-<version>-src.tar.gz` from
 > the [Releases](https://github.com/tizoc/shen-scheme/releases) page. Do **not** use the
-> GitHub-generated "Source code" tarball/zip — it is missing the pre-generated `.scm` files.
+> GitHub-generated "Source code" tarball/zip — it is missing the pre-generated
+> `.scm` files and `shen-scheme-runtime.ss`.
 
-Running `make` should do the job. It will download and compile Chez under the `_build` directory, and then the `shen-scheme` binary and `shen.boot` boot files.
+Running `make` should do the job. It downloads and compiles Chez under the
+`_build` directory, then builds the `shen-scheme` binary and a Shen/Scheme
+runtime object. Shen/Scheme starts from the stock Chez boot files and loads its
+runtime separately; it does not generate a custom boot file.
 
-    make prefix=/opt/shen-scheme # optional prefix, defaults to /usr/local
+```sh
+make prefix=/opt/shen-scheme # optional prefix, defaults to /usr/local
+```
 
-then to install:
+Runtime generation can be configured with
+`SHEN_SCHEME_OPTIMIZE_LEVEL`, `SHEN_SCHEME_DEBUG_LEVEL`,
+`SHEN_SCHEME_INSPECTOR`, and `SHEN_SCHEME_SOURCE_INFO`.
+`make` treats these values as build inputs and rebuilds the runtime when
+they change.
 
-    make install
+Then install with:
 
-This will install the `shen-scheme` binary to `$(prefix)/bin/shen-scheme` and the boot file to `$(prefix)/lib/shen-scheme/shen.boot`.
+```sh
+make install
+```
 
-To build on Windows, an environment with curl, 7zip, make and Visual Studio 2017 is needed (all installable with [chocolatey](https://chocolatey.org/)).
+This installs the binary to `$(prefix)/bin/shen-scheme` and this runtime under
+`$(prefix)/lib/shen-scheme`:
+
+- `petite.boot` and `scheme.boot`: the stock Chez boot files.
+- `shen-scheme/runtime.so`: one Chez object containing both the Shen/Scheme
+  runtime library and launcher.
+
+The nested object path is intentional: it is the path Chez derives for the
+R6RS library `(shen-scheme runtime)`. The build compiles the library and
+launcher as separate units, then combines them for installation.
+
+To build on Windows, an environment with curl, 7zip, make, and Visual Studio
+2017 is needed. These can be installed with [Chocolatey](https://chocolatey.org/).
 
 ### Building from scratch
 
-This step is only necessary if cloning from this repository, the release tarballs include pregenerated `.scm` files.
+This step is only necessary if cloning from this repository. The release tarballs
+include pre-generated `.scm` files.
 
-To build from source, obtain a [copy of the Shen kernel distribution](https://github.com/Shen-Language/shen-sources/releases) and copy the `.kl` files to the `kl/` directory of shen-scheme. Then with a working Shen implementation do:
+To build from source, obtain a
+[copy of the Shen kernel distribution](https://github.com/Shen-Language/shen-sources/releases)
+and copy the `.kl` files to the `kl/` directory of Shen/Scheme. Then with a
+working Shen implementation do:
 
-    (load "scripts/build.shen")
-    (build program "shen-scheme.scm")
+```shen
+(load "scripts/build.shen")
+(build program "shen-scheme.scm")
+```
 
-This will produce `.scm` files in the `compiled/` directory and a `shen-scheme.scm` file in the current directory.
+This produces `.scm` files in the `compiled/` directory plus
+`shen-scheme.scm` and `shen-scheme-runtime.ss` in the current directory.
 
 After doing this the procedure is the same as building from the source distribution.
 
 Running
 -------
 
-`shen-scheme` will start the Shen REPL.
-`shen-scheme script <some shen file>` will run a script.
-`shen-scheme eval <shen expression>` will evaluate an expression.
+`shen-scheme` starts the Shen REPL. The explicit `repl` command does the same
+thing.
 
-Home and Boot file search path
-------------------------------
-
-Shen/Scheme will use as its *home directory* a path relative to the executable: `../lib/shen-scheme`.
-For example, if the executable is `/usr/local/bin/shen-bin` then the *home directory* will be `/usr/local/lib/shen-scheme`.
-This can be overriden by the `SHEN_SCHEME_HOME` environment variable.
-
-By default, the boot file will be loaded from `<shen-scheme-home>/shen.boot`, but the location can be overriden with the `SHEN_SCHEME_BOOT` environment variable.
-
-Native Calls
-------------
-
-Scheme functions live under the `scm` namespace (`scm.` prefix), and the names need to be wrapped with the `foreign` form in calls. For example: `((foreign scm.write) [1 2 3 4])` invokes Scheme's `write` function with a list as an argument.
-
-Because Scheme functions can have variable numbers of arguments and the code passed to `scm.` is not preprocessed, any imported function that is intended to support partial application has to be wrapped with a `defun`:
-
+```sh
+shen-scheme
+shen-scheme repl
 ```
+
+Run a script with:
+
+```sh
+shen-scheme script path/to/script.shen
+```
+
+Evaluate expressions and files with:
+
+```sh
+shen-scheme eval -e "(+ 1 2)"
+shen-scheme eval -l path/to/file.shen -e "(main)"
+```
+
+Use `--help` for the full launcher and native compilation command list:
+
+```sh
+shen-scheme --help
+```
+
+Native Compilation
+------------------
+
+Native compilation is explicit and does not change normal REPL, `script`,
+`eval`, or Shen `load` behavior. Its `.so` outputs are Chez object files, not
+operating-system shared libraries or standalone executables.
+
+The commands below assume a source checkout. In a binary release, skip `make`
+and use `./bin/shen-scheme` in place of `./_build/bin/shen-scheme`.
+
+| Goal | Use |
+| --- | --- |
+| Compile one source file and preserve normal redefinition behavior | `compile` (the default `compatible` mode) |
+| Bind calls within one source unit for speed | `compile --mode sealed` |
+| Describe exports, metadata, and dependencies | `compile-module` and `load-module` with `.shenmod` files |
+| Bundle an ordered set of source files | `build-app` |
+| Bundle a closed `.shenmod` dependency graph | `build-module-app` |
+
+A runnable first example from the repository root is:
+
+```sh
+mkdir -p _build/native-examples
+./_build/bin/shen-scheme compile examples/native/single-file.shen \
+  -o _build/native-examples/single-file.so
+./_build/bin/shen-scheme eval \
+  -e '(shen-scheme.load-compiled "_build/native-examples/single-file.so")' \
+  -e '(answer 5)'
+```
+
+The final expression returns `26`.
+
+See the [native examples](examples/native/README.md) for compatible versus
+sealed binding, packages and effects, module dependencies, bundled apps, WPO,
+and full-to-Petite deployment. The
+[native compilation guide](docs/native-compilation.md) documents the complete
+CLI, `.shenmod` format, Shen API, metadata behavior, limitations, embedding,
+deployment, and benchmarks.
+
+Home and runtime selection
+--------------------------
+
+Shen/Scheme will use as its *home directory* a path relative to the executable:
+`../lib/shen-scheme`.
+For example, if the executable is `/usr/local/bin/shen-bin` then the
+*home directory* will be `/usr/local/lib/shen-scheme`.
+This can be overridden by the `SHEN_SCHEME_HOME` environment variable.
+
+By default, the launcher registers `<shen-scheme-home>/petite.boot` and
+`<shen-scheme-home>/scheme.boot`, then loads the composite
+`<shen-scheme-home>/shen-scheme/runtime.so`. This full runtime supports the
+native compilation commands.
+
+`SHEN_SCHEME_RUNTIME` accepts `full` (the default) or `petite`. Petite mode
+registers only `petite.boot`; it still loads the Shen/Scheme runtime and
+can run Shen and load precompiled native artifacts, but native compilation
+commands are unavailable.
+
+`SHEN_SCHEME_BOOT` is no longer used. Set `SHEN_SCHEME_HOME` when selecting a
+different, internally consistent set of boot and runtime artifacts. See
+[Runtime deployment](docs/native-compilation.md#runtime-deployment) for the
+layout, migration notes, and a compiler-free Petite deployment.
+
+Calling Scheme from Shen
+------------------------
+
+Scheme functions live under the `scm` namespace (`scm.` prefix), and names need
+to be wrapped with the `foreign` form in calls. For example,
+`((foreign scm.write) [1 2 3 4])` invokes Scheme's `write` function with a list
+as an argument.
+
+Because Scheme functions can have variable numbers of arguments and the code
+passed to `scm.` is not preprocessed, any imported function that is intended to
+support partial application has to be wrapped with a `defun`:
+
+```shen
 (0-) (defun my-for-each (F L) ((foreign scm.for-each) F L))
 my-for-each
 
@@ -129,11 +229,12 @@ my-for-each
 Literal Scheme Code
 -------------------
 
-Scheme code can be compiled as-is with the `scm.` special form that takes a string with Scheme code as an argument.
+Scheme code can be compiled as-is with the `scm.` special form that takes a
+string with Scheme code as an argument.
 
 Example:
 
-```
+```shen
 (0-) ((foreign scm.) "(+ 1 2)")
 3
 
@@ -145,18 +246,22 @@ test
 [true false symbol symbol]
 ```
 
-Importing bindings from Scheme modules
+Importing Bindings from Scheme Modules
 --------------------------------------
 
-[import expressions](https://cisco.github.io/ChezScheme/csug9.5/libraries.html#./libraries:h4) are supported through the `scm.` prefix. Names will be imported under the `scm.` namespace.
+[Import expressions](https://cisco.github.io/ChezScheme/csug9.5/libraries.html#./libraries:h4)
+are supported through the `scm.` prefix. Names will be imported under the
+`scm.` namespace.
 
 Example:
 
-    (1-) ((foreign scm.import) (rename (rnrs) (+ add-numbers)))
-    #<void>
+```shen
+(1-) ((foreign scm.import) (rename (rnrs) (+ add-numbers)))
+#<void>
 
-    (2-) ((foreign scm.add-numbers) 1 2 3 4)
-    10
+(2-) ((foreign scm.add-numbers) 1 2 3 4)
+10
+```
 
 License
 -------

--- a/benchmarks/port-adapter.shen
+++ b/benchmarks/port-adapter.shen
@@ -1,0 +1,10 @@
+\* Copyright (c) 2012-2026 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(package port-bench
+ [*port-benchmarks* add-benchmark done]
+
+(define add-benchmark
+  Tag Desc F P -> (do (set *port-benchmarks* [[Tag Desc F P] | (value *port-benchmarks*)])
+                      done))
+)

--- a/benchmarks/port-harness.shen
+++ b/benchmarks/port-harness.shen
@@ -1,0 +1,48 @@
+\* Copyright (c) 2012-2026 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(package port-bench
+ [*port-benchmarks* done run]
+
+(define runs-for-power
+  _ 0 -> 1
+  N 1 -> N
+  N P -> (* N (runs-for-power N (- P 1))))
+
+(define reset-benchmarks
+  -> (set *port-benchmarks* []))
+
+(define effective-runs-power
+  P O -> 0 where (> O P)
+  P O -> (- P O))
+
+(define emit-header
+  -> (output "mode|sample|tag|description|runs_power|seconds|result~%"))
+
+(define run-one
+  Mode Sample O [Tag Desc F P]
+  -> (let P* (effective-runs-power P O)
+          Runs (runs-for-power 10 P*)
+          Start (get-time run)
+          Result (F Runs)
+          End (get-time run)
+          Elapsed (- End Start)
+       (do
+        (output "~A|~A|~A|~A|~A|~A|~R~%" Mode Sample Tag Desc P* Elapsed Result)
+        Elapsed)))
+
+(define run-benchmark-samples
+  _ _ _ Sample Samples -> done where (> Sample Samples)
+  Mode O B Sample Samples
+  -> (do (run-one Mode Sample O B)
+         (run-benchmark-samples Mode O B (+ Sample 1) Samples)))
+
+(define run-benchmarks*
+  _ _ _ [] -> done
+  Mode O Samples [B | Bs]
+  -> (do (run-benchmark-samples Mode O B 1 Samples)
+         (run-benchmarks* Mode O Samples Bs)))
+
+(define run-benchmarks
+  Mode O Samples -> (run-benchmarks* Mode O Samples (reverse (value *port-benchmarks*))))
+)

--- a/benchmarks/port/README.md
+++ b/benchmarks/port/README.md
@@ -1,0 +1,15 @@
+# Port benchmark sources
+
+The five `.shen` workload files in this directory are copied byte-for-byte from
+the [`Shen-Language/shen-sources`](https://github.com/Shen-Language/shen-sources)
+benchmark suite at commit `93ed67eb2ba12558a165147142fb356483578cce`.
+
+Keep these files in sync with the upstream sources rather than editing them
+locally. Shen/Scheme-specific compilation, registration, and reporting belong
+in the runner, harness, and module descriptors outside the copied files.
+
+The copies intentionally retain upstream behavior. In particular, `vector-read`
+and `vector-write` recurse through the abstract-vector helpers after their first
+iteration, and the input labelled `shen.pvar? (true)` is not a tagged Prolog
+variable in Shen/Scheme. Changes to those benchmarks should be made upstream
+first and then synced here.

--- a/benchmarks/port/control-flow.shen
+++ b/benchmarks/port/control-flow.shen
@@ -1,0 +1,217 @@
+\\ Copyright (c) 2019 Bruno Deferrari.
+\\ BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause
+
+(define control-flow-control-loop
+  _ 0 -> ok
+  C N -> (control-flow-control-loop C (- N 1)))
+
+(define control-flow-helper
+  false -> ok
+  true -> (simple-error "error"))
+
+(define control-flow-make-dict
+  -> (let Dict (shen.dict 1000)
+          _ (shen.dict-> Dict "exists" 1)
+       Dict))
+
+(define thaw-test
+  _ R 0 -> R
+  F _ N -> (thaw-test F (thaw F) (- N 1)))
+
+(define lambda/one-arg
+  _ R 0 -> R
+  Lambda _ N -> (lambda/one-arg Lambda (Lambda 1) (- N 1)))
+
+(define lambda/many-args
+  _ R 0 -> R
+  Lambda _ N -> (let Result (Lambda 1 2 3 4 5 6 7 8 9)
+                  (lambda/many-args Lambda Result (- N 1))))
+
+(define trap-error/basic
+  _ R 0 -> R
+  Raise _ N -> (let Result (trap-error (control-flow-helper Raise) (/. E N))
+                 (trap-error/basic Raise Result (- N 1))))
+
+(define trap-error/value
+  _ R 0 -> R
+  Sym _ N -> (let Result (trap-error (value Sym) (/. E default))
+               (trap-error/value Sym Result (- N 1))))
+
+(define trap-error/value-using-error
+  _ R 0 -> R
+  Sym _ N -> (let Result (trap-error (value Sym) (/. E E))
+               (trap-error/value-using-error Sym Result (- N 1))))
+
+(define trap-error/get
+  _ _ R 0 -> R
+  Sym Prop _ N -> (let Result (trap-error (get Sym Prop) (/. E default))
+                    (trap-error/get Sym Prop Result (- N 1))))
+
+(define trap-error/get-using-error
+  _ _ R 0 -> R
+  Sym Prop _ N -> (let Result (trap-error (get Sym Prop) (/. E E))
+                    (trap-error/get-using-error Sym Prop Result (- N 1))))
+
+(define trap-error/<-dict
+  _ _ R 0 -> R
+  Dict Key _ N -> (let Result (trap-error (shen.<-dict Dict Key) (/. E default))
+                    (trap-error/<-dict Dict Key Result (- N 1))))
+
+(define trap-error/<-dict-using-error
+  _ _ R 0 -> R
+  Dict Key _ N -> (let Result (trap-error (shen.<-dict Dict Key) (/. E E))
+                    (trap-error/<-dict-using-error Dict Key Result (- N 1))))
+
+(define trap-error/<-address
+  _ _ R 0 -> R
+  Vec Idx _ N -> (let Result (trap-error (<-address Vec Idx) (/. E default))
+                   (trap-error/<-address Vec Idx Result (- N 1))))
+
+(define trap-error/<-address-using-error
+  _ _ R 0 -> R
+  Vec Idx _ N -> (let Result (trap-error (<-address Vec Idx) (/. E E))
+                   (trap-error/<-address-using-error Vec Idx Result (- N 1))))
+
+(define trap-error/<-vector
+  _ _ R 0 -> R
+  Vec Idx _ N -> (let Result (trap-error (<-vector Vec Idx) (/. E default))
+                   (trap-error/<-vector Vec Idx Result (- N 1))))
+
+(define trap-error/<-vector-using-error
+  _ _ R 0 -> R
+  Vec Idx _ N -> (let Result (trap-error (<-vector Vec Idx) (/. E E))
+                   (trap-error/<-vector-using-error Vec Idx Result (- N 1))))
+
+(add-benchmark control-flow
+  "control flow control loop"
+  (control-flow-control-loop 0)
+  6)
+
+(add-benchmark control-flow
+  "thaw"
+  (thaw-test (freeze 1) unit)
+  6)
+
+(add-benchmark control-flow
+  "lambda with one argument"
+  (lambda/one-arg (/. X X) unit)
+  6)
+
+(add-benchmark control-flow
+  "lambda with many arguments"
+  (lambda/many-args (/. A B C D E F G H X X) unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error basic (no error raised)"
+  (trap-error/basic false unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error basic (error raised)"
+  (trap-error/basic true unit)
+  6)
+
+(set exists 1)
+
+(add-benchmark control-flow
+  "trap-error with value and handler to return default (no error raised)"
+  (trap-error/value exists unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error with value and handler to return default (error raised)"
+  (trap-error/value doesnt-exist unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error with value and handler that uses error (no error raised)"
+  (trap-error/value-using-error exists unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error with value and handler that uses error (error raised)"
+  (trap-error/value-using-error doesnt-exist unit)
+  6)
+
+(put exists exists 1)
+
+(add-benchmark control-flow
+  "trap-error with get and handler to return default value (no error raised)"
+  (trap-error/get exists exists unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error with get and handler to return default value (error raised)"
+  (trap-error/get exists doesnt-exist unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error with get and handler that uses error (no error raised)"
+  (trap-error/get-using-error exists exists unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error with get and handler that uses error (error raised)"
+  (trap-error/get-using-error exists doesnt-exist unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error with shen.<-dict and handler to return default value (no error raised)"
+  (trap-error/<-dict (control-flow-make-dict) "exists" unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error with shen.<-dict and handler to return default value (error raised)"
+  (trap-error/<-dict (control-flow-make-dict) "doesnt-exists" unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error with shen.<-dict and handler that uses error (no error raised)"
+  (trap-error/<-dict-using-error (control-flow-make-dict) "exists" unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error with shen.<-dict and handler that uses error (error raised)"
+  (trap-error/<-dict-using-error (control-flow-make-dict) "doesnt-exists" unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error with <-address and handler to return default value (no error raised)"
+  (trap-error/<-address (@v 1 2 3 4 <>) 3 unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error with <-address and handler to return default value (error raised)"
+  (trap-error/<-address (@v 1 2 3 4 <>) 10 unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error with <-address and handler that uses error (no error raised)"
+  (trap-error/<-address-using-error (@v 1 2 3 4 <>) 3 unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error with <-address and handler that uses error (error raised)"
+  (trap-error/<-address-using-error (@v 1 2 3 4 <>) 10 unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error with <-vector and handler to return default value (no error raised)"
+  (trap-error/<-vector (@v 1 2 3 4 <>) 3 unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error with <-vector and handler to return default value (error raised)"
+  (trap-error/<-vector (@v 1 2 3 4 <>) 10 unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error with <-vector and handler that uses error (no error raised)"
+  (trap-error/<-vector-using-error (@v 1 2 3 4 <>) 3 unit)
+  6)
+
+(add-benchmark control-flow
+  "trap-error with <-vector and handler that uses error (error raised)"
+  (trap-error/<-vector-using-error (@v 1 2 3 4 <>) 10 unit)
+  6)

--- a/benchmarks/port/data.shen
+++ b/benchmarks/port/data.shen
@@ -1,0 +1,172 @@
+\\ Copyright (c) 2019 Bruno Deferrari.
+\\ BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause
+
+(define data-control-loop
+  _ 0 -> ok
+  C N -> (data-control-loop C (- N 1)))
+
+(define absvector-create-small
+  V 0 -> V
+  V N -> (absvector-create-small (absvector 1) (- N 1)))
+
+(define absvector-create-big
+  V 0 -> V
+  V N -> (absvector-create-big (absvector 100) (- N 1)))
+
+(define absvector-read
+  _ R 0 -> R
+  V _ N -> (absvector-read V (<-address V 1) (- N 1)))
+
+(define absvector-write
+  V 0 -> V
+  V N -> (absvector-write (address-> V 1 N) (- N 1)))
+
+(define vector-create-small
+  V 0 -> V
+  V N -> (vector-create-small (vector 1) (- N 1)))
+
+(define vector-create-big
+  V 0 -> V
+  V N -> (vector-create-big (vector 100) (- N 1)))
+
+(define vector-read
+  _ R 0 -> R
+  V _ N -> (absvector-read V (<-vector V 1) (- N 1)))
+
+(define vector-write
+  V 0 -> V
+  V N -> (absvector-write (vector-> V 1 N) (- N 1)))
+
+(define tuple-create
+  T 0 -> T
+  T N -> (tuple-create (@p 1 2) (- N 1)))
+
+(define tuple-read
+  _ R 0 -> R
+  T _ N -> (tuple-read T (fst T) (- N 1)))
+
+(define string-prepend-one
+  _ R 0 -> R
+  S _ N -> (string-prepend-one S (cn "a" S) (- N 1)))
+
+(define string-prepend-long
+  _ R 0 -> R
+  S _ N -> (string-prepend-long S (cn "abcdefghijklmnopqrstuvwxyz" S) (- N 1)))
+
+(define string-read-first
+  _ R 0 -> R
+  S _ N -> (string-read-first S (hdstr S) (- N 1)))
+
+(define string-read-last
+  _ R 0 -> R
+  S _ N -> (string-read-last S (pos S 63) (- N 1)))
+
+(define string-get-tail
+  _ R 0 -> R
+  S _ N -> (string-get-tail S (tlstr S) (- N 1)))
+
+(define dict-create
+  D 0 -> D
+  D N -> (dict-create (shen.dict 100) (- N 1)))
+
+(define dict-read
+  _ R 0 -> R
+  D _ N -> (dict-read D (shen.<-dict D "exists") (- N 1)))
+
+(define dict-write
+  _ 0 -> ok
+  D N -> (dict-write (do (shen.dict-> D "key" 1) D) (- N 1)))
+
+(add-benchmark data
+  "data control loop"
+  (data-control-loop 0)
+  8)
+
+(add-benchmark data
+  "absvector read"
+  (absvector-read (@v 1 <>) 1)
+  8)
+(add-benchmark data
+  "absvector write"
+  (absvector-write (@v 2 <>))
+  8)
+(add-benchmark data
+  "absvector create (small)"
+  (absvector-create-small (absvector 1))
+  7)
+(add-benchmark data
+  "absvector create (big)"
+  (absvector-create-big (absvector 1))
+  7)
+
+(add-benchmark data
+  "vector read"
+  (vector-read (@v 1 <>) 1)
+  8)
+(add-benchmark data
+  "vector write"
+  (vector-write (@v 2 <>))
+  8)
+(add-benchmark data
+  "vector create (small)"
+  (vector-create-small (vector 1))
+  7)
+(add-benchmark data
+  "vector create (big)"
+  (vector-create-big (vector 1))
+  7)
+
+(add-benchmark data
+  "tuple read"
+  (tuple-read (@p 1 2) 1)
+  8)
+(add-benchmark data
+  "tuple create"
+  (tuple-create (@p 1 2))
+  7)
+
+(add-benchmark data
+  "string (short) prepend one"
+  (string-prepend-one "string" "")
+  7)
+(add-benchmark data
+  "string (short) prepend long"
+  (string-prepend-long "string" "")
+  7)
+(add-benchmark data
+  "string (long) prepend one"
+  (string-prepend-one "a longer string a longer string a longer string a longer string." "")
+  7)
+(add-benchmark data
+  "string (long) prepend long"
+  (string-prepend-long "a longer string a longer string a longer string a longer string." "")
+  7)
+(add-benchmark data
+  "string read first"
+  (string-read-first "string" "")
+  8)
+(add-benchmark data
+  "string read last"
+  (string-read-last "a longer string a longer string a longer string a longer string." "")
+  8)
+(add-benchmark data
+  "string get tail (short)"
+  (string-get-tail "string" "")
+  8)
+(add-benchmark data
+  "string get tail (longer)"
+  (string-get-tail "a longer string a longer string a longer string a longer string." "")
+  7)
+
+(add-benchmark data
+  "dict read"
+  (dict-read (let D (shen.dict 100) _ (shen.dict-> D "exists" 1 ) D) 1)
+  7)
+(add-benchmark data
+  "dict write"
+  (dict-write (shen.dict 100))
+  7)
+(add-benchmark data
+  "dict create"
+  (dict-create (shen.dict 100))
+  7)

--- a/benchmarks/port/equality-check.shen
+++ b/benchmarks/port/equality-check.shen
@@ -1,0 +1,112 @@
+\\ Copyright (c) 2019 Bruno Deferrari.
+\\ BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause
+
+(define equality-check-control-loop
+  _ 0 -> ok
+  C N -> (equality-check-control-loop C (- N 1)))
+
+(define equal-values
+  _ _ R 0 -> R
+  ValA ValB _ N -> (equal-values ValA ValB (= ValA ValB) (- N 1)))
+
+(define equal-symbol-literal
+  _ R 0 -> R
+  Sym _ N -> (equal-symbol-literal Sym (= Sym symbol) (- N 1)))
+
+(define equal-integer-literal
+  _ R 0 -> R
+  Num _ N -> (equal-integer-literal Num (= Num 8) (- N 1)))
+
+(define equal-float-literal
+  _ R 0 -> R
+  Num _ N -> (equal-float-literal Num (= Num 8.0) (- N 1)))
+
+(define equal-string-literal
+  _ R 0 -> R
+  Str _ N -> (equal-string-literal Str (= Str "string") (- N 1)))
+
+(add-benchmark equality-check
+  "equality check control loop"
+  (equality-check-control-loop 0)
+  8)
+
+(add-benchmark equality-check
+  "symbol equality (true)"
+  (equal-values symbol symbol false)
+  8)
+(add-benchmark equality-check
+  "symbol equality (false)"
+  (equal-values symbol "not a symbol" false)
+  8)
+
+(add-benchmark equality-check
+  "literal symbol equality (true)"
+  (equal-symbol-literal symbol true)
+  8)
+(add-benchmark equality-check
+  "literal symbol equality (false)"
+  (equal-symbol-literal "not a symbol" false)
+  8)
+
+(add-benchmark equality-check
+  "number equality (true)"
+  (equal-values 1 1 true)
+  8)
+(add-benchmark equality-check
+  "number equality (false)"
+  (equal-values 1 "not a number" false)
+  8)
+
+(add-benchmark equality-check
+  "literal integer equality (true)"
+  (equal-integer-literal 8 true)
+  8)
+(add-benchmark equality-check
+  "literal integer equality (false)"
+  (equal-integer-literal "not a number" false)
+  8)
+
+(add-benchmark equality-check
+  "literal float equality (true)"
+  (equal-float-literal 8.0 true)
+  8)
+(add-benchmark equality-check
+  "literal float equality (false)"
+  (equal-float-literal "not a number" false)
+  8)
+
+(add-benchmark equality-check
+  "string equality (true)"
+  (equal-values "string" "string" true)
+  8)
+(add-benchmark equality-check
+  "string equality (false)"
+  (equal-values "string" [not-a-string] false)
+  8)
+
+(add-benchmark equality-check
+  "literal string equality (true)"
+  (equal-string-literal "string" true)
+  8)
+(add-benchmark equality-check
+  "literal string equality (false)"
+  (equal-string-literal [not-a-string] false)
+  8)
+
+(add-benchmark equality-check
+  "list equality (true)"
+  (equal-values [a list of symbols] [a list of symbols] true)
+  8)
+(add-benchmark equality-check
+  "list equality (false)"
+  (equal-values [a list of symbols] "not a list" false)
+  8)
+
+(add-benchmark equality-check
+  "vector equality (true)"
+  (equal-values (@v a vector of symbols <>) (@v a vector of symbols <>) true)
+  8)
+(add-benchmark equality-check
+  "vector equality (false)"
+  (equal-values (@v a vector of symbols <>) "not a vector" false)
+  8)

--- a/benchmarks/port/pattern-matching.shen
+++ b/benchmarks/port/pattern-matching.shen
@@ -1,0 +1,163 @@
+\\ Copyright (c) 2019 Bruno Deferrari.
+\\ BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause
+
+(define pattern-matching-control-loop
+  R 0 -> R
+  C N -> (pattern-matching-control-loop C (- N 1)))
+
+(define match-list-single
+  R 0 -> R
+  [A B C D E F G H I J K L] N -> (match-list-single [A B C D E F G H I J K L] (- N 1))
+  Other N -> (match-list-single Other (- N 1)))
+
+(define match-list-multiple
+  R 0 -> R
+  [A B C D E F G H I J K 0] N -> (match-list-multiple [A B C D E F G H I J K 0] (- N 1))
+  [A B C D E F G H I J K 1] N -> (match-list-multiple [A B C D E F G H I J K 1] (- N 1))
+  [A B C D E F G H I J K 2] N -> (match-list-multiple [A B C D E F G H I J K 2] (- N 1))
+  [A B C D E F G H I J K 3] N -> (match-list-multiple [A B C D E F G H I J K 3] (- N 1))
+  [A B C D E F G H I J K 4] N -> (match-list-multiple [A B C D E F G H I J K 4] (- N 1))
+  [A B C D E F G H I J K 5] N -> (match-list-multiple [A B C D E F G H I J K 5] (- N 1))
+  [A B C D E F G H I J K 6] N -> (match-list-multiple [A B C D E F G H I J K 6] (- N 1))
+  [A B C D E F G H I J K 7] N -> (match-list-multiple [A B C D E F G H I J K 7] (- N 1))
+  [A B C D E F G H I J K 8] N -> (match-list-multiple [A B C D E F G H I J K 8] (- N 1))
+  [A B C D E F G H I J K 9] N -> (match-list-multiple [A B C D E F G H I J K 9] (- N 1))
+  [A B C D E F G H I J K L] N -> (match-list-multiple [A B C D E F G H I J K L] (- N 1))
+  Other N -> (match-list-multiple Other (- N 1)))
+
+(define match-tuple-single
+  R 0 -> R
+  (@p A B C D E F G H I J K L) N -> (match-tuple-single (@p A B C D E F G H I J K L) (- N 1))
+  Other N -> (match-tuple-single Other (- N 1)))
+
+(define match-tuple-multiple
+  R 0 -> R
+  (@p A B C D E F G H I J K 0) N -> (match-tuple-multiple (@p A B C D E F G H I J K 0) (- N 1))
+  (@p A B C D E F G H I J K 1) N -> (match-tuple-multiple (@p A B C D E F G H I J K 1) (- N 1))
+  (@p A B C D E F G H I J K 2) N -> (match-tuple-multiple (@p A B C D E F G H I J K 2) (- N 1))
+  (@p A B C D E F G H I J K 3) N -> (match-tuple-multiple (@p A B C D E F G H I J K 3) (- N 1))
+  (@p A B C D E F G H I J K 4) N -> (match-tuple-multiple (@p A B C D E F G H I J K 4) (- N 1))
+  (@p A B C D E F G H I J K 5) N -> (match-tuple-multiple (@p A B C D E F G H I J K 5) (- N 1))
+  (@p A B C D E F G H I J K 6) N -> (match-tuple-multiple (@p A B C D E F G H I J K 6) (- N 1))
+  (@p A B C D E F G H I J K 7) N -> (match-tuple-multiple (@p A B C D E F G H I J K 7) (- N 1))
+  (@p A B C D E F G H I J K 8) N -> (match-tuple-multiple (@p A B C D E F G H I J K 8) (- N 1))
+  (@p A B C D E F G H I J K 9) N -> (match-tuple-multiple (@p A B C D E F G H I J K 9) (- N 1))
+  (@p A B C D E F G H I J K L) N -> (match-tuple-multiple (@p A B C D E F G H I J K L) (- N 1))
+  Other N -> (match-tuple-multiple Other (- N 1)))
+
+(define match-vector-single
+  R 0 -> R
+  (@v A B C D E F G H I J K L <>) N -> (match-vector-single (@v A B C D E F G H I J K L <>) (- N 1))
+  Other N -> (match-vector-single Other (- N 1)))
+
+(define match-vector-multiple
+  R 0 -> R
+  (@v A B C D E F G H I J K 0 <>) N -> (match-vector-multiple (@v A B C D E F G H I J K 0 <>) (- N 1))
+  (@v A B C D E F G H I J K 1 <>) N -> (match-vector-multiple (@v A B C D E F G H I J K 1 <>) (- N 1))
+  (@v A B C D E F G H I J K 2 <>) N -> (match-vector-multiple (@v A B C D E F G H I J K 2 <>) (- N 1))
+  (@v A B C D E F G H I J K 3 <>) N -> (match-vector-multiple (@v A B C D E F G H I J K 3 <>) (- N 1))
+  (@v A B C D E F G H I J K 4 <>) N -> (match-vector-multiple (@v A B C D E F G H I J K 4 <>) (- N 1))
+  (@v A B C D E F G H I J K 5 <>) N -> (match-vector-multiple (@v A B C D E F G H I J K 5 <>) (- N 1))
+  (@v A B C D E F G H I J K 6 <>) N -> (match-vector-multiple (@v A B C D E F G H I J K 6 <>) (- N 1))
+  (@v A B C D E F G H I J K 7 <>) N -> (match-vector-multiple (@v A B C D E F G H I J K 7 <>) (- N 1))
+  (@v A B C D E F G H I J K 8 <>) N -> (match-vector-multiple (@v A B C D E F G H I J K 8 <>) (- N 1))
+  (@v A B C D E F G H I J K 9 <>) N -> (match-vector-multiple (@v A B C D E F G H I J K 9 <>) (- N 1))
+  (@v A B C D E F G H I J K L <>) N -> (match-vector-multiple (@v A B C D E F G H I J K L <>) (- N 1))
+  Other N -> (match-vector-multiple Other (- N 1)))
+
+(define match-string-single
+  R 0 -> R
+  (@s A B C D E F G H I J K L "X") N -> (match-string-single (@s A B C D E F G H I J K L "X") (- N 1))
+  Other N -> (match-string-single Other (- N 1)))
+
+(define match-string-multiple
+  R 0 -> R
+  (@s A B C D E F G H I J K L "A") N -> (match-string-multiple (@s A B C D E F G H I J K L "A") (- N 1))
+  (@s A B C D E F G H I J K L "B") N -> (match-string-multiple (@s A B C D E F G H I J K L "B") (- N 1))
+  (@s A B C D E F G H I J K L "C") N -> (match-string-multiple (@s A B C D E F G H I J K L "C") (- N 1))
+  (@s A B C D E F G H I J K L "D") N -> (match-string-multiple (@s A B C D E F G H I J K L "D") (- N 1))
+  (@s A B C D E F G H I J K L "E") N -> (match-string-multiple (@s A B C D E F G H I J K L "E") (- N 1))
+  (@s A B C D E F G H I J K L "F") N -> (match-string-multiple (@s A B C D E F G H I J K L "F") (- N 1))
+  (@s A B C D E F G H I J K L "G") N -> (match-string-multiple (@s A B C D E F G H I J K L "G") (- N 1))
+  (@s A B C D E F G H I J K L "H") N -> (match-string-multiple (@s A B C D E F G H I J K L "H") (- N 1))
+  (@s A B C D E F G H I J K L "I") N -> (match-string-multiple (@s A B C D E F G H I J K L "I") (- N 1))
+  (@s A B C D E F G H I J K L "J") N -> (match-string-multiple (@s A B C D E F G H I J K L "J") (- N 1))
+  (@s A B C D E F G H I J K L "X") N -> (match-string-multiple (@s A B C D E F G H I J K L "X") (- N 1))
+  Other N -> (match-string-multiple Other (- N 1)))
+
+(add-benchmark pattern-matching
+  "pattern-matching control loop"
+  (pattern-matching-control-loop 0)
+  8)
+
+(add-benchmark pattern-matching
+  "match list (single clause, matching)"
+  (match-list-single [0 1 2 3 4 5 6 7 8 9 9 9])
+  8)
+(add-benchmark pattern-matching
+  "match list (single clause, not matching)"
+  (match-list-single other)
+  8)
+
+(add-benchmark pattern-matching
+  "match list (multiple clauses, matching)"
+  (match-list-multiple [0 1 2 3 4 5 6 7 8 9 9 9])
+  8)
+(add-benchmark pattern-matching
+  "match list (multiple clauses, not matching)"
+  (match-list-multiple other)
+  8)
+
+(add-benchmark pattern-matching
+  "match tuple (single clause, matching)"
+  (match-tuple-single (@p 0 1 2 3 4 5 6 7 8 9 9 9))
+  7)
+(add-benchmark pattern-matching
+  "match tuple (single clause, not matching)"
+  (match-tuple-single other)
+  8)
+
+(add-benchmark pattern-matching
+  "match tuple (multiple clauses, matching)"
+  (match-tuple-multiple (@p 0 1 2 3 4 5 6 7 8 9 9 9))
+  7)
+(add-benchmark pattern-matching
+  "match tuple (multiple clauses, not matching)"
+  (match-tuple-multiple other)
+  8)
+
+(add-benchmark pattern-matching
+  "match vector (single clause, matching)"
+  (match-vector-single (@v 0 1 2 3 4 5 6 7 8 9 9 9 <>))
+  4)
+(add-benchmark pattern-matching
+  "match vector (single clause, not matching)"
+  (match-vector-single other)
+  8)
+
+(add-benchmark pattern-matching
+  "match vector (multiple clauses, matching)"
+  (match-vector-multiple (@v 0 1 2 3 4 5 6 7 8 9 9 9 <>))
+  4)
+(add-benchmark pattern-matching
+  "match vector (multiple clauses, not matching)"
+  (match-vector-multiple other)
+  8)
+
+(add-benchmark pattern-matching
+  "match string (single clause, matching)"
+  (match-string-single "ABCDEFGHIJKLX")
+  6)
+(add-benchmark pattern-matching
+  "match string (single clause, not matching)"
+  (match-string-single other)
+  8)
+
+(add-benchmark pattern-matching
+  "match string (multiple clauses, matching)"
+  (match-string-multiple "ABCDEFGHIJKLX")
+  6)
+(add-benchmark pattern-matching
+  "match string (multiple clauses, not matching)"
+  (match-string-multiple other)
+  8)

--- a/benchmarks/port/port-bench.whole-compatible.shenmod
+++ b/benchmarks/port/port-bench.whole-compatible.shenmod
@@ -1,0 +1,9 @@
+(shen.aot.module
+  (name port.bench.whole-compatible)
+  (mode compatible)
+  (sources "benchmarks/port-adapter.shen"
+           "benchmarks/port/data.shen"
+           "benchmarks/port/control-flow.shen"
+           "benchmarks/port/shen-compilation.shen"
+           "benchmarks/port/pattern-matching.shen"
+           "benchmarks/port/equality-check.shen"))

--- a/benchmarks/port/port-bench.whole-sealed.shenmod
+++ b/benchmarks/port/port-bench.whole-sealed.shenmod
@@ -1,0 +1,9 @@
+(shen.aot.module
+  (name port.bench.whole-sealed)
+  (mode sealed)
+  (sources "benchmarks/port-adapter.shen"
+           "benchmarks/port/data.shen"
+           "benchmarks/port/control-flow.shen"
+           "benchmarks/port/shen-compilation.shen"
+           "benchmarks/port/pattern-matching.shen"
+           "benchmarks/port/equality-check.shen"))

--- a/benchmarks/port/shen-compilation.shen
+++ b/benchmarks/port/shen-compilation.shen
@@ -1,0 +1,63 @@
+\\ Copyright (c) 2019 Bruno Deferrari.
+\\ BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause
+
+(define shen-compilation-control-loop
+  _ 0 -> ok
+  C N -> (shen-compilation-control-loop C (- N 1)))
+
+(define loop-shen.pvar?
+  _ R 0 -> R
+  V _ N -> (loop-shen.pvar? V (shen.pvar? V) (- N 1)))
+
+(define loop-variable?
+  _ R 0 -> R
+  V _ N -> (loop-variable? V (variable? V) (- N 1)))
+
+(define loop-symbol?
+  _ R 0 -> R
+  V _ N -> (loop-symbol? V (symbol? V) (- N 1)))
+
+(define loop-sysfunc?
+  _ R 0 -> R
+  V _ N -> (loop-sysfunc? V (shen.sysfunc? V) (- N 1)))
+
+(add-benchmark shen-compilation
+  "compilation control loop"
+  (shen-compilation-control-loop 0)
+  8)
+
+(add-benchmark shen-compilation
+  "shen.pvar? (true)"
+  (loop-shen.pvar? (@v 1 <>) true)
+  8)
+(add-benchmark shen-compilation
+  "shen.pvar? (false)"
+  (loop-shen.pvar? (@v 1 <>) false)
+  8)
+
+(add-benchmark shen-compilation
+  "variable? (true)"
+  (loop-variable? Variable true)
+  8)
+(add-benchmark shen-compilation
+  "variable? (false)"
+  (loop-variable? [not a variable] false)
+  8)
+
+(add-benchmark shen-compilation
+  "symbol? (true)"
+  (loop-symbol? symbol true)
+  7)
+(add-benchmark shen-compilation
+  "symbol? (false)"
+  (loop-symbol? [not a symbol] false)
+  8)
+
+(add-benchmark shen-compilation
+  "shen.sysfunc? (true)"
+  (loop-sysfunc? cons true)
+  5)
+(add-benchmark shen-compilation
+  "shen.sysfunc? (false)"
+  (loop-sysfunc? not-a-sysfunc false)
+  5)

--- a/benchmarks/realistic-registrations.shen
+++ b/benchmarks/realistic-registrations.shen
@@ -1,0 +1,15 @@
+\* Copyright (c) 2012-2026 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(package realistic-bench
+ [*port-benchmarks* add-benchmark realistic-pipeline realistic-vm]
+
+(set *port-benchmarks* [])
+
+(add-benchmark realistic-pipeline "compile pipeline depth 5" (run-pipeline 5 2) 4)
+(add-benchmark realistic-pipeline "compile pipeline depth 7" (run-pipeline 7 3) 4)
+(add-benchmark realistic-pipeline "compile pipeline depth 9" (run-pipeline 9 3) 3)
+
+(add-benchmark realistic-vm "bytecode VM depth 7" (run-bytecode 7 3) 6)
+(add-benchmark realistic-vm "bytecode VM depth 9" (run-bytecode 9 3) 6)
+)

--- a/benchmarks/realistic/analysis.shen
+++ b/benchmarks/realistic/analysis.shen
@@ -1,0 +1,24 @@
+\* Copyright (c) 2012-2026 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(package realistic-bench
+ [num var add sub mul let1]
+
+(define free-vars
+  [num _] -> []
+  [var N] -> [N]
+  [add A B] -> (union-vars (free-vars A) (free-vars B))
+  [sub A B] -> (union-vars (free-vars A) (free-vars B))
+  [mul A B] -> (union-vars (free-vars A) (free-vars B))
+  [let1 N V B] -> (union-vars (free-vars V) (remove-var N (free-vars B)))
+  _ -> [])
+
+(define ast-size
+  [num _] -> 1
+  [var _] -> 1
+  [add A B] -> (+ 1 (ast-size A) (ast-size B))
+  [sub A B] -> (+ 1 (ast-size A) (ast-size B))
+  [mul A B] -> (+ 1 (ast-size A) (ast-size B))
+  [let1 _ V B] -> (+ 1 (ast-size V) (ast-size B))
+  _ -> 0)
+)

--- a/benchmarks/realistic/compile.shen
+++ b/benchmarks/realistic/compile.shen
@@ -1,0 +1,15 @@
+\* Copyright (c) 2012-2026 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(package realistic-bench
+ [num var add sub mul let1 const load add-op sub-op mul-op bind unbind]
+
+(define compile-ast
+  [num N] -> [[const N]]
+  [var N] -> [[load N]]
+  [add A B] -> (append (compile-ast A) (compile-ast B) [[add-op]])
+  [sub A B] -> (append (compile-ast A) (compile-ast B) [[sub-op]])
+  [mul A B] -> (append (compile-ast A) (compile-ast B) [[mul-op]])
+  [let1 N V B] -> (append (compile-ast V) [[bind N]] (compile-ast B) [[unbind]])
+  X -> (error "realistic benchmark cannot compile expression: ~S~%" X))
+)

--- a/benchmarks/realistic/core.shen
+++ b/benchmarks/realistic/core.shen
@@ -1,0 +1,54 @@
+\* Copyright (c) 2012-2026 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(package realistic-bench
+ [num var add sub mul let1]
+
+(define member?
+  _ [] -> false
+  X [X | _] -> true
+  X [_ | Xs] -> (member? X Xs))
+
+(define add-unique
+  X Xs -> Xs where (member? X Xs)
+  X Xs -> [X | Xs])
+
+(define union-vars
+  [] Ys -> Ys
+  [X | Xs] Ys -> (union-vars Xs (add-unique X Ys)))
+
+(define remove-var
+  _ [] -> []
+  X [X | Xs] -> (remove-var X Xs)
+  X [Y | Ys] -> [Y | (remove-var X Ys)])
+
+(define list-length
+  Xs -> (list-length* Xs 0))
+
+(define list-length*
+  [] N -> N
+  [_ | Xs] N -> (list-length* Xs (+ N 1)))
+
+(define env-lookup
+  _ [] -> 0
+  N [[N V] | _] -> V
+  N [_ | E] -> (env-lookup N E))
+
+(define initial-env
+  S -> [[0 (+ S 1)]])
+
+(define make-program
+  D -> [let1 0 [num 7] (make-block D 1)])
+
+(define make-block
+  0 S -> [add [var 0] [num S]]
+  D S -> [let1 S
+               (make-expr D S)
+               [add (make-block (- D 1) (+ S 1))
+                    [mul [var S] [num (+ S 3)]]]])
+
+(define make-expr
+  0 S -> [add [var 0] [num S]]
+  D S -> [add [mul [var (- S 1)] [num (+ D S)]]
+              [sub [num (* D S)] [var 0]]])
+)

--- a/benchmarks/realistic/main.shen
+++ b/benchmarks/realistic/main.shen
@@ -1,0 +1,35 @@
+\* Copyright (c) 2012-2026 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(package realistic-bench
+ []
+
+(define pipeline
+  D P S -> (let Program (make-program D)
+                 Normal (normalise Program)
+                 Vars (free-vars Normal)
+                 Optimised (optimise-ast Normal P)
+                 Code (compile-ast Optimised)
+                 Value (run-code Code (initial-env S))
+              (+ Value (list-length Vars) (ast-size Optimised))))
+
+(define pipeline-loop
+  _ _ _ Result 0 -> Result
+  D P S _ N -> (pipeline-loop D P (+ S 1) (pipeline D P S) (- N 1)))
+
+(define run-pipeline
+  D P N -> (pipeline-loop D P 0 0 N))
+
+(define prepare-code
+  D P -> (let Program (make-program D)
+              Optimised (optimise-ast (normalise Program) P)
+           (compile-ast Optimised)))
+
+(define bytecode-loop
+  _ _ Result 0 -> Result
+  Code S _ N -> (bytecode-loop Code (+ S 1) (run-code Code (initial-env S)) (- N 1)))
+
+(define run-bytecode
+  D P N -> (let Code (prepare-code D P)
+             (bytecode-loop Code 0 0 N)))
+)

--- a/benchmarks/realistic/optimize.shen
+++ b/benchmarks/realistic/optimize.shen
@@ -1,0 +1,46 @@
+\* Copyright (c) 2012-2026 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(package realistic-bench
+ [num var add sub mul let1]
+
+(define normalise
+  [num N] -> [num N]
+  [var N] -> [var N]
+  [add A B] -> [add (normalise A) (normalise B)]
+  [sub A B] -> [add (normalise A) [mul [num -1] (normalise B)]]
+  [mul A B] -> [mul (normalise A) (normalise B)]
+  [let1 N V B] -> [let1 N (normalise V) (normalise B)]
+  X -> X)
+
+(define simplify
+  [num N] -> [num N]
+  [var N] -> [var N]
+  [add A B] -> (simplify-add (simplify A) (simplify B))
+  [sub A B] -> (simplify [add A [mul [num -1] B]])
+  [mul A B] -> (simplify-mul (simplify A) (simplify B))
+  [let1 N V B] -> (simplify-let N (simplify V) (simplify B))
+  X -> X)
+
+(define simplify-add
+  [num 0] B -> B
+  A [num 0] -> A
+  [num A] [num B] -> [num (+ A B)]
+  A B -> [add A B])
+
+(define simplify-mul
+  [num 0] _ -> [num 0]
+  _ [num 0] -> [num 0]
+  [num 1] B -> B
+  A [num 1] -> A
+  [num A] [num B] -> [num (* A B)]
+  A B -> [mul A B])
+
+(define simplify-let
+  N V B -> [let1 N V B] where (member? N (free-vars B))
+  _ _ B -> B)
+
+(define optimise-ast
+  X 0 -> X
+  X N -> (optimise-ast (simplify (normalise X)) (- N 1)))
+)

--- a/benchmarks/realistic/realistic.bench.analysis.shenmod
+++ b/benchmarks/realistic/realistic.bench.analysis.shenmod
@@ -1,0 +1,7 @@
+(shen.aot.module
+  (name realistic.bench.analysis)
+  (mode sealed)
+  (requires realistic.bench.core)
+  (exports realistic-bench.free-vars
+           realistic-bench.ast-size)
+  (sources "benchmarks/realistic/analysis.shen"))

--- a/benchmarks/realistic/realistic.bench.compile.shenmod
+++ b/benchmarks/realistic/realistic.bench.compile.shenmod
@@ -1,0 +1,5 @@
+(shen.aot.module
+  (name realistic.bench.compile)
+  (mode sealed)
+  (exports realistic-bench.compile-ast)
+  (sources "benchmarks/realistic/compile.shen"))

--- a/benchmarks/realistic/realistic.bench.core.shenmod
+++ b/benchmarks/realistic/realistic.bench.core.shenmod
@@ -1,0 +1,14 @@
+(shen.aot.module
+  (name realistic.bench.core)
+  (mode sealed)
+  (exports realistic-bench.member?
+           realistic-bench.add-unique
+           realistic-bench.union-vars
+           realistic-bench.remove-var
+           realistic-bench.list-length
+           realistic-bench.env-lookup
+           realistic-bench.initial-env
+           realistic-bench.make-program
+           realistic-bench.make-block
+           realistic-bench.make-expr)
+  (sources "benchmarks/realistic/core.shen"))

--- a/benchmarks/realistic/realistic.bench.main.shenmod
+++ b/benchmarks/realistic/realistic.bench.main.shenmod
@@ -1,0 +1,15 @@
+(shen.aot.module
+  (name realistic.bench.main)
+  (mode sealed)
+  (requires realistic.bench.core
+            realistic.bench.analysis
+            realistic.bench.optimize
+            realistic.bench.compile
+            realistic.bench.vm)
+  (exports realistic-bench.pipeline
+           realistic-bench.pipeline-loop
+           realistic-bench.run-pipeline
+           realistic-bench.prepare-code
+           realistic-bench.bytecode-loop
+           realistic-bench.run-bytecode)
+  (sources "benchmarks/realistic/main.shen"))

--- a/benchmarks/realistic/realistic.bench.optimize.shenmod
+++ b/benchmarks/realistic/realistic.bench.optimize.shenmod
@@ -1,0 +1,12 @@
+(shen.aot.module
+  (name realistic.bench.optimize)
+  (mode sealed)
+  (requires realistic.bench.core
+            realistic.bench.analysis)
+  (exports realistic-bench.normalise
+           realistic-bench.simplify
+           realistic-bench.simplify-add
+           realistic-bench.simplify-mul
+           realistic-bench.simplify-let
+           realistic-bench.optimise-ast)
+  (sources "benchmarks/realistic/optimize.shen"))

--- a/benchmarks/realistic/realistic.bench.vm.shenmod
+++ b/benchmarks/realistic/realistic.bench.vm.shenmod
@@ -1,0 +1,17 @@
+(shen.aot.module
+  (name realistic.bench.vm)
+  (mode sealed)
+  (requires realistic.bench.core)
+  (exports realistic-bench.run-code
+           realistic-bench.push-const
+           realistic-bench.push-load
+           realistic-bench.add-values
+           realistic-bench.sub-values
+           realistic-bench.mul-values
+           realistic-bench.apply-add
+           realistic-bench.apply-sub
+           realistic-bench.apply-mul
+           realistic-bench.push-binding
+           realistic-bench.drop-binding
+           realistic-bench.exec)
+  (sources "benchmarks/realistic/vm.shen"))

--- a/benchmarks/realistic/realistic.bench.whole-compatible.shenmod
+++ b/benchmarks/realistic/realistic.bench.whole-compatible.shenmod
@@ -1,0 +1,9 @@
+(shen.aot.module
+  (name realistic.bench.whole-compatible)
+  (mode compatible)
+  (sources "benchmarks/realistic/core.shen"
+           "benchmarks/realistic/analysis.shen"
+           "benchmarks/realistic/optimize.shen"
+           "benchmarks/realistic/compile.shen"
+           "benchmarks/realistic/vm.shen"
+           "benchmarks/realistic/main.shen"))

--- a/benchmarks/realistic/realistic.bench.whole-sealed.shenmod
+++ b/benchmarks/realistic/realistic.bench.whole-sealed.shenmod
@@ -1,0 +1,9 @@
+(shen.aot.module
+  (name realistic.bench.whole-sealed)
+  (mode sealed)
+  (sources "benchmarks/realistic/core.shen"
+           "benchmarks/realistic/analysis.shen"
+           "benchmarks/realistic/optimize.shen"
+           "benchmarks/realistic/compile.shen"
+           "benchmarks/realistic/vm.shen"
+           "benchmarks/realistic/main.shen"))

--- a/benchmarks/realistic/vm.shen
+++ b/benchmarks/realistic/vm.shen
@@ -1,0 +1,51 @@
+\* Copyright (c) 2012-2026 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(package realistic-bench
+ [const load add-op sub-op mul-op bind unbind]
+
+(define run-code
+  Code E -> (exec Code [] E))
+
+(define push-const
+  N S -> [N | S])
+
+(define push-load
+  N S E -> [(env-lookup N E) | S])
+
+(define add-values
+  L R -> (+ L R))
+
+(define sub-values
+  L R -> (- L R))
+
+(define mul-values
+  L R -> (* L R))
+
+(define apply-add
+  L R S -> [(add-values L R) | S])
+
+(define apply-sub
+  L R S -> [(sub-values L R) | S])
+
+(define apply-mul
+  L R S -> [(mul-values L R) | S])
+
+(define push-binding
+  N V E -> [[N V] | E])
+
+(define drop-binding
+  [_ | E] -> E
+  [] -> [])
+
+(define exec
+  [] [R | _] _ -> R
+  [[const N] | Is] S E -> (exec Is (push-const N S) E)
+  [[load N] | Is] S E -> (exec Is (push-load N S E) E)
+  [[add-op] | Is] [R L | S] E -> (exec Is (apply-add L R S) E)
+  [[sub-op] | Is] [R L | S] E -> (exec Is (apply-sub L R S) E)
+  [[mul-op] | Is] [R L | S] E -> (exec Is (apply-mul L R S) E)
+  [[bind N] | Is] [V | S] E -> (exec Is S (push-binding N V E))
+  [[unbind] | Is] S E -> (exec Is S (drop-binding E))
+  [Op | _] S E -> (error "realistic benchmark VM failed at ~S with stack ~S and env ~S~%" Op S E))
+)

--- a/benchmarks/run-port-comparison.shen
+++ b/benchmarks/run-port-comparison.shen
@@ -1,0 +1,147 @@
+\* Copyright (c) 2012-2026 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(package port-bench
+ [*argv* dynamic compatible sealed app app-wpo done
+  scm. file-exists? mkdir string->number
+  shen-scheme.compile-module
+  shen-scheme.build-module-app/profile
+  shen-scheme.build-module-app/wpo/profile
+  shen-scheme.load-compiled]
+
+(define sources
+  -> ["benchmarks/port/data.shen"
+      "benchmarks/port/control-flow.shen"
+      "benchmarks/port/shen-compilation.shen"
+      "benchmarks/port/pattern-matching.shen"
+      "benchmarks/port/equality-check.shen"])
+
+(define harness-source
+  -> "benchmarks/port-harness.shen")
+
+(define adapter-source
+  -> "benchmarks/port-adapter.shen")
+
+(define module-dir
+  -> "benchmarks/port")
+
+(define descriptor
+  compatible -> "benchmarks/port/port-bench.whole-compatible.shenmod"
+  sealed -> "benchmarks/port/port-bench.whole-sealed.shenmod"
+  app -> "benchmarks/port/port-bench.whole-sealed.shenmod"
+  app-wpo -> "benchmarks/port/port-bench.whole-sealed.shenmod")
+
+(define output-dir
+  -> "_build/native-bench")
+
+(define object-path
+  Mode -> (make-string "~A/port-bench-~A.so" (output-dir) Mode))
+
+(define ensure-directory
+  D -> D where (eval-kl [scm. [file-exists? D]])
+  D -> (do (eval-kl [scm. [mkdir D]]) D))
+
+(define ensure-output-directory
+  -> (do (ensure-directory "_build") (ensure-directory (output-dir))))
+
+(define load-sources
+  [] -> loaded
+  [Source | Sources] -> (do (load Source) (load-sources Sources)))
+
+(define script-args
+  -> (if (bound? *argv*)
+         (tl (value *argv*))
+         []))
+
+(define arg-mode
+  "dynamic" -> dynamic
+  "compatible" -> compatible
+  "sealed" -> sealed
+  "app" -> app
+  "app-wpo" -> app-wpo
+  _ -> (fail))
+
+(define arg-modes
+  [] -> []
+  [Arg | Args] -> (let Mode (arg-mode Arg)
+                    (if (= Mode (fail))
+                        (arg-modes Args)
+                        [Mode | (arg-modes Args)])))
+
+(define modes
+  Args -> (let Modes (arg-modes Args)
+            (if (= Modes [])
+                [dynamic compatible sealed app app-wpo]
+                Modes)))
+
+(define string->number*
+  S -> (eval-kl [scm. [string->number S]]))
+
+(define option-number
+  Flag S -> (let N (string->number* S)
+              (if (= N false)
+                  (error "~A expected a number, got: ~A~%" Flag S)
+                  N)))
+
+(define quiet
+  F -> (let Old (value *hush*)
+            _ (set *hush* true)
+            X (thaw F)
+            _ (set *hush* Old)
+         X))
+
+(define arg-offset
+  [] -> 0
+  ["--quick" | _] -> 6
+  ["quick" | _] -> 6
+  ["--offset" O | _] -> (option-number "--offset" O)
+  [_ | Args] -> (arg-offset Args))
+
+(define arg-samples
+  [] -> 1
+  ["--samples" N | _] -> (option-number "--samples" N)
+  [_ | Args] -> (arg-samples Args))
+
+(define enable-factorisation
+  -> (trap-error (factorise +) (/. E cannot-factorise)))
+
+(define prepare-mode
+  dynamic -> (load-sources (sources))
+  compatible -> (let O (object-path compatible)
+                  (do (shen-scheme.compile-module (descriptor compatible) O)
+                      (shen-scheme.load-compiled O)))
+  sealed -> (let O (object-path sealed)
+              (do (shen-scheme.compile-module (descriptor sealed) O)
+                  (shen-scheme.load-compiled O)))
+  app -> (let O (object-path app)
+           (do (shen-scheme.build-module-app/profile (descriptor app) (module-dir) O release)
+               (shen-scheme.load-compiled O)))
+  app-wpo -> (let O (object-path app-wpo)
+               (do (shen-scheme.build-module-app/wpo/profile (descriptor app-wpo) (module-dir) O release)
+                   (shen-scheme.load-compiled O)))
+  Mode -> (error "unknown benchmark mode: ~A~%" Mode))
+
+(define run-mode
+  Mode O N -> (do (output "# preparing mode ~A~%" Mode)
+                  (quiet (freeze (do (enable-factorisation) (reset-benchmarks) (prepare-mode Mode))))
+                  (run-benchmarks Mode O N)))
+
+(define run-modes
+  [] _ _ -> done
+  [Mode | Modes] O N -> (do (run-mode Mode O N) (run-modes Modes O N)))
+
+(define main
+  -> (let Args (script-args)
+          Modes (modes Args)
+          O (arg-offset Args)
+          N (arg-samples Args)
+       (do (ensure-output-directory)
+           (quiet (freeze (do (load (adapter-source)) (load (harness-source)))))
+           (output "# modes: ~R~%" Modes)
+           (output "# run_power_offset: ~A~%" O)
+           (output "# samples: ~A~%" N)
+           (emit-header)
+           (run-modes Modes O N))))
+
+(main)
+)

--- a/benchmarks/run-realistic-comparison.shen
+++ b/benchmarks/run-realistic-comparison.shen
@@ -1,0 +1,150 @@
+\* Copyright (c) 2012-2026 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(package realistic-bench
+ [*argv* dynamic compatible sealed app app-wpo done
+  scm. file-exists? mkdir string->number
+  port-bench.emit-header
+  port-bench.run-benchmarks
+  shen-scheme.compile-module
+  shen-scheme.build-module-app/profile
+  shen-scheme.build-module-app/wpo/profile
+  shen-scheme.load-compiled]
+
+(define sources
+  -> ["benchmarks/realistic/core.shen"
+      "benchmarks/realistic/analysis.shen"
+      "benchmarks/realistic/optimize.shen"
+      "benchmarks/realistic/compile.shen"
+      "benchmarks/realistic/vm.shen"
+      "benchmarks/realistic/main.shen"])
+
+(define harness-source
+  -> "benchmarks/port-harness.shen")
+
+(define adapter-source
+  -> "benchmarks/port-adapter.shen")
+
+(define registration-source
+  -> "benchmarks/realistic-registrations.shen")
+
+(define module-dir
+  -> "benchmarks/realistic")
+
+(define output-dir
+  -> "_build/native-bench")
+
+(define object-path
+  Mode -> (make-string "~A/realistic-bench-~A.so" (output-dir) Mode))
+
+(define descriptor
+  compatible -> "benchmarks/realistic/realistic.bench.whole-compatible.shenmod"
+  sealed -> "benchmarks/realistic/realistic.bench.whole-sealed.shenmod"
+  app -> "benchmarks/realistic/realistic.bench.main.shenmod"
+  app-wpo -> "benchmarks/realistic/realistic.bench.main.shenmod")
+
+(define ensure-directory
+  D -> D where (eval-kl [scm. [file-exists? D]])
+  D -> (do (eval-kl [scm. [mkdir D]]) D))
+
+(define ensure-output-directory
+  -> (do (ensure-directory "_build") (ensure-directory (output-dir))))
+
+(define load-sources
+  [] -> loaded
+  [Source | Sources] -> (do (load Source) (load-sources Sources)))
+
+(define script-args
+  -> (if (bound? *argv*)
+         (tl (value *argv*))
+         []))
+
+(define arg-mode
+  "dynamic" -> dynamic
+  "compatible" -> compatible
+  "sealed" -> sealed
+  "app" -> app
+  "app-wpo" -> app-wpo
+  _ -> (fail))
+
+(define arg-modes
+  [] -> []
+  [Arg | Args] -> (let Mode (arg-mode Arg)
+                    (if (= Mode (fail))
+                        (arg-modes Args)
+                        [Mode | (arg-modes Args)])))
+
+(define modes
+  Args -> (let Modes (arg-modes Args)
+            (if (= Modes [])
+                [dynamic compatible sealed app app-wpo]
+                Modes)))
+
+(define string->number*
+  S -> (eval-kl [scm. [string->number S]]))
+
+(define option-number
+  Flag S -> (let N (string->number* S)
+              (if (= N false)
+                  (error "~A expected a number, got: ~A~%" Flag S)
+                  N)))
+
+(define quiet
+  F -> (let Old (value *hush*)
+            _ (set *hush* true)
+            X (thaw F)
+            _ (set *hush* Old)
+         X))
+
+(define arg-offset
+  [] -> 0
+  ["--quick" | _] -> 4
+  ["quick" | _] -> 4
+  ["--offset" O | _] -> (option-number "--offset" O)
+  [_ | Args] -> (arg-offset Args))
+
+(define arg-samples
+  [] -> 1
+  ["--samples" N | _] -> (option-number "--samples" N)
+  [_ | Args] -> (arg-samples Args))
+
+(define prepare-mode
+  dynamic -> (load-sources (sources))
+  compatible -> (let O (object-path compatible)
+                  (do (shen-scheme.compile-module (descriptor compatible) O)
+                      (shen-scheme.load-compiled O)))
+  sealed -> (let O (object-path sealed)
+              (do (shen-scheme.compile-module (descriptor sealed) O)
+                  (shen-scheme.load-compiled O)))
+  app -> (let O (object-path app)
+           (do (shen-scheme.build-module-app/profile (descriptor app) (module-dir) O release)
+               (shen-scheme.load-compiled O)))
+  app-wpo -> (let O (object-path app-wpo)
+               (do (shen-scheme.build-module-app/wpo/profile (descriptor app-wpo) (module-dir) O release)
+                   (shen-scheme.load-compiled O)))
+  Mode -> (error "unknown benchmark mode: ~A~%" Mode))
+
+(define run-mode
+  Mode O N -> (do (output "# preparing mode ~A~%" Mode)
+                  (quiet (freeze (do (prepare-mode Mode) (load (registration-source)))))
+                  (port-bench.run-benchmarks Mode O N)))
+
+(define run-modes
+  [] _ _ -> done
+  [Mode | Modes] O N -> (do (run-mode Mode O N) (run-modes Modes O N)))
+
+(define main
+  -> (let Args (script-args)
+          Modes (modes Args)
+          O (arg-offset Args)
+          N (arg-samples Args)
+       (do (ensure-output-directory)
+           (quiet (freeze (do (load (adapter-source)) (load (harness-source)))))
+           (output "# modes: ~R~%" Modes)
+           (output "# run_power_offset: ~A~%" O)
+           (output "# samples: ~A~%" N)
+           (port-bench.emit-header)
+           (run-modes Modes O N))))
+
+(main)
+)

--- a/docs/native-compilation.md
+++ b/docs/native-compilation.md
@@ -1,0 +1,561 @@
+# Native compilation
+
+Shen/Scheme can compile Shen sources ahead of time to Chez object files. This
+is an explicit workflow: normal REPL evaluation, `script`, `eval`, and Shen
+`load` continue to use the ordinary dynamic path.
+
+Files ending in `.so` in this guide are Chez compiled objects. They are not
+operating-system shared libraries, and application objects are not standalone
+executables. Load them into a matching Shen/Scheme process.
+
+Commands in this guide assume a source checkout. In a binary release, skip
+`make` and use `./bin/shen-scheme` wherever the examples use
+`./_build/bin/shen-scheme`.
+
+## Choose a workflow
+
+| Goal | Command | Result |
+| --- | --- | --- |
+| Compile one source file with ordinary rebinding semantics | `compile` | One loadable object in `compatible` mode |
+| Compile one source unit with locally bound calls | `compile --mode sealed` | One loadable object with faster intra-unit calls |
+| Give a unit a name, exports, metadata, and dependencies | `compile-module` | One standalone module object described by `.shenmod` |
+| Load a compiled module and its compiled dependencies | `load-module` | The dependency graph loaded in dependency order |
+| Bundle an ordered group of raw source files | `build-app` | One loadable application object |
+| Bundle a closed `.shenmod` graph | `build-module-app` | One loadable application object with static module boundaries |
+
+Use ordinary Shen `load` while developing unless ahead-of-time compilation is
+part of what you want to test. Start with `compatible` when code relies on
+redefinition. Use `sealed` or an app builder when the compiled boundary is
+deliberate and performance matters.
+
+The complete command surface is:
+
+```text
+shen-scheme compile SOURCE -o OBJECT
+  [--emit-scheme SCHEME] [--mode compatible|sealed]
+  [--profile release|debug|wpo|unsafe]
+shen-scheme load-compiled OBJECT
+shen-scheme compile-module DECLARATION -o OBJECT
+  [--emit-scheme SCHEME] [--module-dir DIR]
+shen-scheme load-module DECLARATION --module-dir DIR
+shen-scheme build-app MAIN [--module SOURCE ...] -o OBJECT
+  [--wpo] [--profile release|debug|wpo|unsafe]
+shen-scheme build-module-app DECLARATION --module-dir DIR -o OBJECT
+  [--wpo] [--profile release|debug|wpo|unsafe]
+```
+
+Run `shen-scheme COMMAND --help` for the corresponding launcher help.
+
+## Quick start
+
+Build Shen/Scheme, compile the single-file example, then load and call it in
+one process:
+
+```sh
+make
+mkdir -p _build/native-examples
+./_build/bin/shen-scheme compile examples/native/single-file.shen \
+  -o _build/native-examples/single-file.so
+./_build/bin/shen-scheme eval \
+  -e '(shen-scheme.load-compiled "_build/native-examples/single-file.so")' \
+  -e '(answer 5)'
+```
+
+The final expression returns `26`.
+
+The standalone command below loads the object and then exits, so it is useful
+for checking initialization but not for calling a definition afterward:
+
+```sh
+./_build/bin/shen-scheme load-compiled _build/native-examples/single-file.so
+```
+
+The complete runnable examples cover:
+
+- [single-file compilation](../examples/native/single-file.shen);
+- [compatible and sealed binding](../examples/native/binding.shen);
+- [packages and top-level effects](../examples/native/package-effects.shen);
+- [module dependencies and app builds](../examples/native/modules/native-example.app.shenmod);
+- WPO and full-to-Petite deployment.
+
+Follow [the examples README](../examples/native/README.md) from the repository
+root, or run its examples as automated checks with:
+
+```sh
+make test-native-examples
+```
+
+## Direct source compilation
+
+The general command is:
+
+```text
+shen-scheme compile SOURCE -o OBJECT
+  [--emit-scheme SCHEME]
+  [--mode compatible|sealed]
+  [--profile release|debug|wpo|unsafe]
+```
+
+Generated Scheme is normally compiled directly. `--emit-scheme` also writes it
+to the requested path for inspection:
+
+```sh
+./_build/bin/shen-scheme compile examples/native/single-file.shen \
+  -o _build/native-examples/single-file.so \
+  --emit-scheme _build/native-examples/single-file.scm
+```
+
+### Compatible and sealed modes
+
+`compatible` is the default. Definitions use normal top-level bindings, so a
+compiled caller observes a helper that is redefined later:
+
+```sh
+./_build/bin/shen-scheme compile examples/native/binding.shen \
+  -o _build/native-examples/binding-compatible.so
+./_build/bin/shen-scheme eval \
+  -e '(shen-scheme.load-compiled "_build/native-examples/binding-compatible.so")' \
+  -l examples/native/binding-update.shen \
+  -e '(call-helper 1)'
+```
+
+The compatible result is `101`. Compiling the same source with `--mode sealed`
+keeps the original helper binding, so the result after the update is `2`.
+
+`sealed` gives definitions in the same compilation unit local compiled
+bindings. Redefining the top-level helper later does not change calls already
+compiled into that unit:
+
+```sh
+./_build/bin/shen-scheme compile examples/native/binding.shen \
+  -o _build/native-examples/binding-sealed.so --mode sealed
+```
+
+Both modes install the unit's public definitions at Shen top level. Sealing
+changes how definitions inside that unit call one another; it is not an access
+control mechanism by itself.
+
+## Shen packages and native modules
+
+They solve different problems:
+
+- A Shen `package` form is part of the Shen language. It qualifies internal
+  symbols and records the package's external and internal names. Native
+  compilation supports package forms and preserves package registration.
+- A `.shenmod` file is build metadata. It names a compilation unit, lists its
+  source files and dependencies, and controls native exports and metadata. It
+  does not qualify Shen symbols and does not replace `package`.
+
+A source listed by a module can contain one or more packages. The descriptor's
+`exports` are the native boundary; package externals are the Shen namespace
+boundary. Keep both when both concepts are useful.
+
+See [package-effects.shen](../examples/native/package-effects.shen) for a
+package whose effects are restored when its compiled object is loaded.
+
+## Module declarations
+
+A declaration is one raw Shen form. It is read without macro expansion:
+
+```shen
+(shen.aot.module
+  (name my.math)
+  (mode sealed)
+  (requires my.core)
+  (exports my.add my.sum)
+  (metadata runtime compiletime source-kl)
+  (profile release)
+  (sources "src/math.shen"))
+```
+
+| Field | Required/default | Meaning |
+| --- | --- | --- |
+| `name` | Required | Symbolic module name used by `requires` and file lookup |
+| `sources` | Required, one or more paths | Source files forming one compilation unit |
+| `mode` | `compatible` | `compatible` or `sealed` for standalone `compile-module` |
+| `requires` | Empty | Symbolic module dependencies |
+| `exports` | `infer-all` | Exported function names, or every definition |
+| `metadata` | `runtime compiletime` | Any of `runtime`, `compiletime`, and `source-kl` |
+| `profile` | `release` | `release`, `debug`, `wpo`, or `unsafe` for standalone compilation |
+
+Source paths are resolved from the process working directory, not from the
+descriptor's directory. The listed files are read in order and analyzed as one
+unit, so a definition may call another definition appearing in a later source.
+If a function is defined repeatedly, the final definition is compiled.
+
+An explicit export list requires `sealed` mode for a standalone module.
+`compatible` standalone modules use `infer-all`, because dynamically resolved
+top-level calls do not provide a private native boundary.
+
+### Compile and load a graph
+
+The example descriptors are:
+
+- [native-example.core.shenmod](../examples/native/modules/native-example.core.shenmod)
+- [native-example.app.shenmod](../examples/native/modules/native-example.app.shenmod)
+
+Compile each object under the name used by the resolver, then load the root:
+
+```sh
+mkdir -p _build/native-examples/modules
+cp examples/native/modules/*.shenmod _build/native-examples/modules/
+./_build/bin/shen-scheme compile-module \
+  _build/native-examples/modules/native-example.core.shenmod \
+  -o _build/native-examples/modules/native-example.core.so
+./_build/bin/shen-scheme compile-module \
+  _build/native-examples/modules/native-example.app.shenmod \
+  --module-dir _build/native-examples/modules \
+  -o _build/native-examples/modules/native-example.app.so
+./_build/bin/shen-scheme eval \
+  -e '(shen-scheme.load-module "_build/native-examples/modules/native-example.app.shenmod" "_build/native-examples/modules")' \
+  -e '(run-example 32)' \
+  -e '(module-events)'
+```
+
+The last two expressions return `42` and `[42]`.
+
+For a required module named `my.core`, `--module-dir DIR` resolves:
+
+```text
+DIR/my.core.shenmod
+DIR/my.core.so
+```
+
+`compile-module` analyzes dependency declarations and source files in
+topological order. It does not require or load dependency objects, install
+ordinary dependency definitions, or run dependency initializers. Analysis is
+transient: private dependency arities and the compiler state do not leak after
+the build. Exported arities, packages, macros, datatypes, and synonyms are made
+available while compiling dependants.
+
+`load-module` does require every `.so`. It loads dependencies before their
+dependants and returns a list of the loaded module names. Cycles and missing
+declarations or objects are errors. If standalone direct requirements export
+the same function, the later direct requirement takes precedence.
+
+## Application objects
+
+Application builders create one object for code that is deployed together.
+The result still requires the matching Shen/Scheme runtime and must be loaded
+with `load-compiled`; it is not an executable.
+
+### Ordered raw sources
+
+`build-app` takes a main source and zero or more module sources:
+
+```sh
+shen-scheme build-app src/main.shen \
+  --module src/core.shen \
+  --module src/math.shen \
+  -o _build/app.so
+```
+
+Module sources are compiled in command-line order, followed by the main
+source. Later sources can statically call definitions from earlier sources.
+Compile-time forms are available while building, but a raw-source app does not
+replay them when the object is loaded.
+
+### Closed module graph
+
+`build-module-app` starts from a root descriptor and traverses its complete
+dependency graph:
+
+```sh
+./_build/bin/shen-scheme build-module-app \
+  examples/native/modules/native-example.app.shenmod \
+  --module-dir examples/native/modules \
+  -o _build/native-examples/module-app.so
+```
+
+The graph is analyzed and initialized in dependency order. Descriptor exports
+are static cross-module boundaries, so private dependency functions do not
+become visible. Overlapping exports from direct requirements are rejected
+because their static meaning would be ambiguous.
+
+Module-app linkage is static regardless of descriptor `mode`. The app command's
+profile controls the build; descriptor `mode` and `profile` control standalone
+`compile-module` builds. Descriptor metadata is replayed according to each
+module's `metadata` field.
+
+To run work automatically when an app object is loaded, make that work an
+explicit top-level effect. Otherwise the object simply installs its definitions
+and can be called by the loading process.
+
+## Definitions, effects, and metadata
+
+Native sources support:
+
+- ordinary and typed `define`;
+- `defprolog`;
+- `declare`, `defmacro`, `datatype`, and `synonyms`;
+- `package`;
+- other top-level Shen expressions used for effects.
+
+Definitions are hoisted before initializers, including across all sources in a
+single descriptor. Top-level effects do not run while compiling. When the
+object is loaded, definitions and selected metadata are installed first, then
+effects run in their original relative source order. The same rule applies to
+effects inside packages.
+
+Descriptor metadata controls what is restored in the loading Shen image:
+
+- `runtime` records exported arities and installs the needed exported
+  top-level bindings for sealed modules and module apps.
+- `compiletime` replays declarations, macros, datatypes, and synonyms.
+- `source-kl` records KLambda for `ps` and user-definition introspection.
+
+Package external/internal registration is preserved independently of that
+list. Direct source compilation uses runtime and compile-time metadata.
+
+Ordinary foreign Scheme expressions can be top-level effects. A foreign escape
+that produces a Scheme definition-context form such as `define`, `import`,
+`module`, or `library` cannot be used as a native initializer.
+
+## Profiles and WPO
+
+| Profile | Chez settings | Intended use |
+| --- | --- | --- |
+| `release` | Optimize level 2 | Safe optimized default |
+| `debug` | Optimize level 2, debug level 2, inspector and source information | Debugging compiled code |
+| `wpo` | Release settings plus WPO sidecar generation | Whole-program app builds |
+| `unsafe` | Optimize level 3 | Trusted, well-tested code only |
+
+Chez optimize level 3 can omit checks based on compiler assumptions. Incorrect
+type or bounds assumptions can crash the process or corrupt memory.
+
+For app builders, either `--wpo` or `--profile wpo` runs Chez whole-program
+optimization over the generated application libraries:
+
+```sh
+shen-scheme build-module-app modules/my.app.shenmod \
+  --module-dir modules -o _build/app.so --wpo
+```
+
+The Shen/Scheme runtime remains external and is not folded into the app. WPO on
+a direct or standalone module compile produces Chez WPO information, but only
+an app builder has the closed generated program needed to produce the final
+whole-program object.
+
+## Runtime deployment
+
+A normal installation contains:
+
+```text
+bin/shen-scheme
+lib/shen-scheme/petite.boot
+lib/shen-scheme/scheme.boot
+lib/shen-scheme/shen-scheme/runtime.so
+```
+
+The boot files are unmodified Chez files. `runtime.so` is one composite Chez
+object containing the R6RS library `(shen-scheme runtime)` followed by the
+Shen/Scheme launcher program. Chez maps that library name to
+`shen-scheme/runtime.so`, which is why the object is nested one level below the
+boot files.
+
+At startup the C executable:
+
+1. finds its home at `../lib/shen-scheme`, or uses `SHEN_SCHEME_HOME`;
+2. registers `petite.boot` and, in full mode, `scheme.boot`;
+3. loads `shen-scheme/runtime.so` and starts the Shen launcher.
+
+### Migrating from `shen.boot`
+
+Older releases generated a custom `shen.boot`. That file and
+`SHEN_SCHEME_BOOT` are no longer used. Install or select the complete new home
+instead:
+
+```sh
+SHEN_SCHEME_HOME=/opt/shen-scheme/lib/shen-scheme shen-scheme --version
+```
+
+Keep the stock boots and composite runtime from the same Shen/Scheme build
+together. Do not combine runtime artifacts from different releases or Chez
+builds.
+
+### Compiler-free Petite deployment
+
+The default `SHEN_SCHEME_RUNTIME=full` registers both boot files and supports
+native compilation. `petite` registers only `petite.boot`:
+
+```sh
+SHEN_SCHEME_RUNTIME=petite shen-scheme script app.shen
+```
+
+Petite can run Shen and load native objects built by a matching full
+installation. It cannot run the native compilation commands because Chez's
+compiler is absent. A Petite-only deployment may omit `scheme.boot` if every
+launch sets `SHEN_SCHEME_RUNTIME=petite`; it still needs the executable,
+`petite.boot`, and `shen-scheme/runtime.so` in the layout above.
+
+A typical deployment flow is:
+
+1. build the application object with the full runtime;
+2. copy the object alongside an otherwise matching Petite deployment;
+3. start with `SHEN_SCHEME_RUNTIME=petite` and load the object.
+
+`make test-external-runtime` exercises both full and Petite operation.
+
+## Shen API
+
+The CLI is backed by the following supported `shen-scheme` functions. `S`,
+`F`, `M`, `O`, `Scm`, and `Dir` below are source, descriptor, main-source,
+object, generated-Scheme, and directory paths. `P` is a profile symbol and
+`Mode` is `compatible` or `sealed`.
+
+### Source files
+
+```shen
+(shen-scheme.compile-file S O)
+(shen-scheme.compile-file/mode S O Mode)
+(shen-scheme.compile-file/profile S O P)
+(shen-scheme.compile-file/profile/mode S O P Mode)
+
+(shen-scheme.compile-file/emit S O Scm)
+(shen-scheme.compile-file/emit/mode S O Scm Mode)
+(shen-scheme.compile-file/emit/profile S O Scm P)
+(shen-scheme.compile-file/emit/profile/mode S O Scm P Mode)
+```
+
+Each returns `O`.
+
+### Modules and loading
+
+```shen
+(shen-scheme.compile-module F O)
+(shen-scheme.compile-module/in-dir F O Dir)
+(shen-scheme.compile-module/emit F O Scm)
+(shen-scheme.compile-module/emit/in-dir F O Scm Dir)
+(shen-scheme.load-compiled O)
+(shen-scheme.load-module F Dir)
+```
+
+The compilation functions and `load-compiled` return `O`. `load-module`
+returns the loaded module-name list; dependencies are initialized before
+dependants.
+
+### Applications
+
+```shen
+(shen-scheme.build-app M ModuleSources O)
+(shen-scheme.build-app/wpo M ModuleSources O)
+(shen-scheme.build-app/profile M ModuleSources O P)
+(shen-scheme.build-app/wpo/profile M ModuleSources O P)
+
+(shen-scheme.build-module-app F Dir O)
+(shen-scheme.build-module-app/wpo F Dir O)
+(shen-scheme.build-module-app/profile F Dir O P)
+(shen-scheme.build-module-app/wpo/profile F Dir O P)
+```
+
+`ModuleSources` is an ordered list of source paths. An app builder returns:
+
+```shen
+[O RemainingLibraries]
+```
+
+`RemainingLibraries` is `[]` without WPO. For WPO it is Chez's list of
+libraries that remain external to the whole-program object, normally including
+`[shen-scheme runtime]`.
+
+Functions ending in `/options`, including `compile-file/options`,
+`compile-file/emit/options`, `build-app/emit/options`, and
+`build-module-app/emit/options`, expose the compiler's internal option vector
+and scratch-directory controls. They are advanced, lower-level interfaces;
+prefer the mode/profile facade above in application code.
+
+## Embedding as R6RS libraries
+
+The source generator can produce a public `(shen)` R6RS library instead of the
+launcher program. From a Shen/Scheme checkout:
+
+```sh
+mkdir -p _build/embed/shen-scheme
+./_build/bin/shen-scheme eval \
+  -e '(load "scripts/build.shen")' \
+  -e '(set *runtime-library-file* "_build/embed/shen-scheme/runtime.ss")' \
+  -e '(build library "_build/embed/shen.ss")'
+```
+
+This creates two sources:
+
+- `_build/embed/shen-scheme/runtime.ss`, the private
+  `(shen-scheme runtime)` library;
+- `_build/embed/shen.ss`, the public `(shen)` library.
+
+Compile the runtime first, with `_build/embed` as both the source and object
+library root, then compile `shen.ss`. In Chez this is equivalent to:
+
+```scheme
+(parameterize ([library-directories
+                (cons '("_build/embed" . "_build/embed")
+                      (library-directories))])
+  (compile-file "_build/embed/shen-scheme/runtime.ss"
+                "_build/embed/shen-scheme/runtime.so")
+  (compile-file "_build/embed/shen.ss"
+                "_build/embed/shen.so"))
+```
+
+An embedding program imports `(shen)`, calls `initialize-shen` once, and then
+uses its exported `kl:` bindings. Hosts that use native compilation must also
+register the `get_shen_scheme_home_path` callback used to locate runtime
+artifacts. The optional CFFI conversion helpers additionally require
+`scm_make_utf8_string` and `scm_make_bytevector`. The supplied `shen-scheme`
+launcher registers all three.
+
+## Benchmarks
+
+The port and realistic suites compare five execution modes:
+
+```text
+dynamic compatible sealed app app-wpo
+```
+
+Run every mode:
+
+```sh
+make bench-port
+make bench-realistic
+```
+
+Pass runner arguments through the corresponding make variable:
+
+```sh
+make bench-port PORT_BENCH_ARGS='sealed app-wpo --offset 2 --samples 5'
+make bench-realistic REALISTIC_BENCH_ARGS='compatible sealed --samples 3'
+```
+
+Recognized arguments are:
+
+- any subset of the five mode names; all modes run if none is given;
+- `--samples N` for repeated samples;
+- `--offset N` to reduce each benchmark's base-10 run exponent by `N`;
+- `--quick` (or `quick`) for the suite's smoke-test offset.
+
+`make bench-port-smoke` and `make bench-realistic-smoke` select quick mode.
+After comment lines beginning with `#`, results are pipe-delimited:
+
+```text
+mode|sample|tag|description|runs_power|seconds|result
+```
+
+Compilation chatter is suppressed so the data rows can be consumed directly.
+The primitive workloads are vendored unchanged from `shen-sources`; see their
+[provenance and cross-port notes](https://github.com/tizoc/shen-scheme/blob/master/benchmarks/port/README.md).
+
+## Limitations and artifact compatibility
+
+- A dependency macro must be self-contained or use helpers already present in
+  the compiler. Ordinary helpers defined only in dependency source are not
+  installed during dependency analysis.
+- Macro transformer names share the live compiler namespace and must not
+  collide with existing bindings.
+- Unusual compile-time rewrites that depend on another module's `declare`
+  forms must be arranged by the caller.
+- Foreign Scheme definition-context forms cannot be native initializers.
+- A raw-source app does not replay compile-time forms when loaded.
+
+Native outputs are build artifacts. Rebuild them when source files, profile,
+Shen/Scheme, Chez, operating system, or architecture changes. They are not a
+portable module format and are expected to be loaded only by the matching
+runtime that produced them.

--- a/examples/native/README.md
+++ b/examples/native/README.md
@@ -1,0 +1,137 @@
+# Native compilation examples
+
+Run these examples from the repository root after building Shen/Scheme:
+
+```sh
+make
+mkdir -p _build/native-examples
+```
+
+In a binary release, skip `make` and use `./bin/shen-scheme` in place of
+`./_build/bin/shen-scheme`.
+
+The `.so` files below are Chez compiled objects, not operating-system shared
+libraries.
+
+## Compile one source file
+
+Compile a source file and load the result in the same process that calls it:
+
+```sh
+./_build/bin/shen-scheme compile examples/native/single-file.shen \
+  -o _build/native-examples/single-file.so
+./_build/bin/shen-scheme eval \
+  -e '(shen-scheme.load-compiled "_build/native-examples/single-file.so")' \
+  -e '(answer 5)'
+```
+
+The last expression evaluates to `26`. `load-compiled` as a launcher command
+loads an object and exits; use `eval` when later expressions need its functions.
+
+## Compatible and sealed calls
+
+Compatible mode is the default. A compiled caller observes a later top-level
+redefinition of its helper:
+
+```sh
+./_build/bin/shen-scheme compile examples/native/binding.shen \
+  -o _build/native-examples/compatible.so
+./_build/bin/shen-scheme eval \
+  -e '(shen-scheme.load-compiled "_build/native-examples/compatible.so")' \
+  -e '(load "examples/native/binding-update.shen")' \
+  -e '(call-helper 1)'
+```
+
+This evaluates to `101`. Compile the same source in sealed mode and the caller
+keeps its statically bound helper, so the final expression evaluates to `2`:
+
+```sh
+./_build/bin/shen-scheme compile examples/native/binding.shen --mode sealed \
+  -o _build/native-examples/sealed.so
+./_build/bin/shen-scheme eval \
+  -e '(shen-scheme.load-compiled "_build/native-examples/sealed.so")' \
+  -e '(load "examples/native/binding-update.shen")' \
+  -e '(call-helper 1)'
+```
+
+## Packages and top-level effects
+
+Native compilation accepts normal `package` forms and delays top-level effects
+until the object is loaded. Definitions are installed first, so an initializer
+can call `record` before its textual definition:
+
+```sh
+./_build/bin/shen-scheme compile examples/native/package-effects.shen \
+  -o _build/native-examples/package-effects.so
+./_build/bin/shen-scheme eval \
+  -e '(shen-scheme.load-compiled "_build/native-examples/package-effects.so")' \
+  -e '(effect-events)'
+```
+
+The two string values print as `[inside-before-definition after-definition]`,
+preserving the source order of the effects.
+
+## Compile and load a module graph
+
+A Shen package controls source-level qualification. A `.shenmod` declaration
+instead describes native compilation, dependencies, exports, and metadata. The
+example modules use both mechanisms.
+
+`load-module` resolves both declarations and compiled objects by module name in
+one module directory. Copy the declarations to the build directory so generated
+objects stay outside the source tree:
+
+```sh
+mkdir -p _build/native-examples/modules
+cp examples/native/modules/*.shenmod _build/native-examples/modules/
+
+./_build/bin/shen-scheme compile-module \
+  _build/native-examples/modules/native-example.core.shenmod \
+  -o _build/native-examples/modules/native-example.core.so
+./_build/bin/shen-scheme compile-module \
+  _build/native-examples/modules/native-example.app.shenmod \
+  --module-dir _build/native-examples/modules \
+  -o _build/native-examples/modules/native-example.app.so
+./_build/bin/shen-scheme eval \
+  -e '(shen-scheme.load-module "_build/native-examples/modules/native-example.app.shenmod" "_build/native-examples/modules")' \
+  -e '(run-example 32)' \
+  -e '(module-events)'
+```
+
+The last two expressions evaluate to `42` and `[42]`. The core module is loaded
+before the app module, and only its declared export is available for native
+cross-module calls.
+
+## Build one application object
+
+`build-module-app` bundles the closed descriptor graph into one object:
+
+```sh
+./_build/bin/shen-scheme build-module-app \
+  _build/native-examples/modules/native-example.app.shenmod \
+  --module-dir _build/native-examples/modules \
+  -o _build/native-examples/app.so
+./_build/bin/shen-scheme eval \
+  -e '(shen-scheme.load-compiled "_build/native-examples/app.so")' \
+  -e '(run-example 32)'
+```
+
+Add `--wpo` to the build command to run Chez whole-program optimization over
+the application graph.
+
+## Load a full-runtime artifact with Petite
+
+Compile with the default full runtime, then select the compiler-free runtime
+when loading the object:
+
+```sh
+./_build/bin/shen-scheme compile examples/native/single-file.shen \
+  -o _build/native-examples/full-to-petite.so
+SHEN_SCHEME_RUNTIME=petite ./_build/bin/shen-scheme eval \
+  -e '(shen-scheme.load-compiled "_build/native-examples/full-to-petite.so")' \
+  -e '(answer 5)'
+```
+
+`make test-native-examples` validates the examples through the module-app build.
+`make test-external-runtime` verifies full-runtime compilation, Petite loading,
+and the expected absence of the compiler in Petite mode.

--- a/examples/native/binding-update.shen
+++ b/examples/native/binding-update.shen
@@ -1,0 +1,6 @@
+(package native-example.binding
+ []
+
+(define helper
+  X -> (+ X 100))
+)

--- a/examples/native/binding.shen
+++ b/examples/native/binding.shen
@@ -1,0 +1,9 @@
+(package native-example.binding
+ [call-helper]
+
+(define helper
+  X -> (+ X 1))
+
+(define call-helper
+  X -> (helper X))
+)

--- a/examples/native/modules/native-example.app.shen
+++ b/examples/native/modules/native-example.app.shen
@@ -1,0 +1,13 @@
+(package native-example.app
+ (append [run-example module-events] (external native-example.core))
+
+(set *events* [])
+
+(define run-example
+  X -> (add-ten X))
+
+(set *events* [(run-example 32)])
+
+(define module-events
+  -> (value *events*))
+)

--- a/examples/native/modules/native-example.app.shenmod
+++ b/examples/native/modules/native-example.app.shenmod
@@ -1,0 +1,7 @@
+(shen.aot.module
+  (name native-example.app)
+  (mode sealed)
+  (requires native-example.core)
+  (exports run-example module-events)
+  (metadata runtime compiletime)
+  (sources "examples/native/modules/native-example.app.shen"))

--- a/examples/native/modules/native-example.core.shen
+++ b/examples/native/modules/native-example.core.shen
@@ -1,0 +1,9 @@
+(package native-example.core
+ [add-ten]
+
+(define increment
+  X -> (+ X 1))
+
+(define add-ten
+  X -> (+ (increment X) 9))
+)

--- a/examples/native/modules/native-example.core.shenmod
+++ b/examples/native/modules/native-example.core.shenmod
@@ -1,0 +1,6 @@
+(shen.aot.module
+  (name native-example.core)
+  (mode sealed)
+  (exports add-ten)
+  (metadata runtime compiletime)
+  (sources "examples/native/modules/native-example.core.shen"))

--- a/examples/native/package-effects.shen
+++ b/examples/native/package-effects.shen
@@ -1,0 +1,15 @@
+(package native-example.effects
+ [effect-events]
+
+(set *events* [])
+
+(record "inside-before-definition")
+
+(define record
+  X -> (set *events* (append (value *events*) [X])))
+
+(record "after-definition")
+
+(define effect-events
+  -> (value *events*))
+)

--- a/examples/native/single-file.shen
+++ b/examples/native/single-file.shen
@@ -1,0 +1,5 @@
+(define square
+  X -> (* X X))
+
+(define answer
+  X -> (+ (square X) 1))

--- a/main.c
+++ b/main.c
@@ -7,65 +7,182 @@
 #include <string.h>
 
 #ifdef _WIN32
-#   include <windows.h>
-#   include <io.h>
-#   define F_OK 0
-#   define PATH_MAX _MAX_PATH
-#   define access _access
-#   define PATH_SEPARATOR "\\"
+#include <io.h>
+#include <windows.h>
+#define PATH_CAPACITY (_MAX_PATH * 4)
+#define PATH_SEPARATOR "\\"
 #else
-#   include <unistd.h>
-#   include <limits.h>
-#   define PATH_SEPARATOR "/"
-#   ifdef __APPLE__
-#     include <mach-o/dyld.h>
-#     define strcpy_s(dest, size, src) strlcpy(dest, src, size)
-#   else
-#     define strcpy_s(dest, size, src) snprintf(dest, size, "%s", src)
-#   endif
+#include <limits.h>
+#include <unistd.h>
+#define PATH_CAPACITY PATH_MAX
+#define PATH_SEPARATOR "/"
 #endif
 
-static char shen_scheme_home_path[PATH_MAX];
-static char shen_scheme_bootfile_path[PATH_MAX];
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
+
+#ifndef R_OK
+#define R_OK 4
+#endif
+
+#if defined(_WIN32) && !defined(__MINGW32__)
+#define GETENV Sgetenv
+#define FREE_ENV free
+#else
+#define GETENV getenv
+#define FREE_ENV(value) ((void)(value))
+#endif
+
+static char shen_scheme_home_path[PATH_CAPACITY];
+static char petite_boot_path[PATH_CAPACITY];
+static char scheme_boot_path[PATH_CAPACITY];
+static char runtime_object_path[PATH_CAPACITY];
+static int petite_runtime;
+
+static void fail(const char *message, const char *path) {
+  if (path)
+    fprintf(stderr, "ERROR: %s: %s\n", message, path);
+  else
+    fprintf(stderr, "ERROR: %s\n", message);
+  exit(1);
+}
+
+static void copy_path(char *destination, const char *source) {
+  size_t length = strlen(source);
+
+  if (length >= PATH_CAPACITY)
+    fail("path is too long", source);
+  memcpy(destination, source, length + 1);
+}
+
+static int is_path_separator(char character) {
+#ifdef _WIN32
+  return character == '/' || character == '\\';
+#else
+  return character == '/';
+#endif
+}
+
+static void parent_path(char *path) {
+  size_t length = strlen(path);
+
+  while (length > 1 && is_path_separator(path[length - 1]))
+    path[--length] = '\0';
+  while (length > 0 && !is_path_separator(path[length - 1]))
+    length--;
+  if (length == 0)
+    fail("cannot determine the executable's parent directory", path);
+  if (length == 1)
+    path[1] = '\0';
+  else
+    path[length - 1] = '\0';
+}
+
+static void join_path(char *destination, const char *directory,
+                      const char *name) {
+  size_t length = strlen(directory);
+  const char *separator =
+      length > 0 && is_path_separator(directory[length - 1])
+          ? ""
+          : PATH_SEPARATOR;
+  int written = snprintf(destination, PATH_CAPACITY, "%s%s%s", directory,
+                         separator, name);
+
+  if (written < 0 || written >= PATH_CAPACITY)
+    fail("path is too long", directory);
+}
+
+static void executable_path(char *path) {
+#ifdef _WIN32
+  wchar_t wide_path[_MAX_PATH];
+  char *utf8_path;
+  DWORD length = GetModuleFileNameW(NULL, wide_path, _MAX_PATH);
+
+  if (length == 0 || length >= _MAX_PATH)
+    fail("cannot determine the executable path", NULL);
+  wide_path[length] = L'\0';
+  utf8_path = Swide_to_utf8(wide_path);
+  if (utf8_path == NULL)
+    fail("cannot convert the executable path to UTF-8", NULL);
+  copy_path(path, utf8_path);
+  free(utf8_path);
+#elif defined(__APPLE__)
+  uint32_t size = PATH_CAPACITY;
+  char unresolved_path[PATH_CAPACITY];
+
+  if (_NSGetExecutablePath(unresolved_path, &size) != 0)
+    fail("executable path is too long", NULL);
+  if (realpath(unresolved_path, path) == NULL)
+    fail("cannot resolve the executable path", unresolved_path);
+#else
+  ssize_t length = readlink("/proc/self/exe", path, PATH_CAPACITY - 1);
+
+  if (length < 0)
+    fail("cannot determine the executable path", "/proc/self/exe");
+  if (length >= PATH_CAPACITY - 1)
+    fail("executable path is too long", "/proc/self/exe");
+  path[length] = '\0';
+#endif
+}
+
+static void require_readable(const char *message, const char *path) {
+#ifdef _WIN32
+  wchar_t *wide_path = Sutf8_to_wide(path);
+  int readable =
+      wide_path != NULL && _waccess(wide_path, R_OK) == 0;
+
+  free(wide_path);
+#else
+  int readable = access(path, R_OK) == 0;
+#endif
+
+  if (!readable)
+    fail(message, path);
+}
 
 static void initialize_paths(void) {
-  char *sshpath = getenv("SHEN_SCHEME_HOME");
-  char *ssbfpath = getenv("SHEN_SCHEME_BOOT");
-#ifdef __APPLE__
-  char tmpbuf[PATH_MAX];
-#endif
+  char *home = GETENV("SHEN_SCHEME_HOME");
+  char *runtime = GETENV("SHEN_SCHEME_RUNTIME");
+  char executable[PATH_CAPACITY];
+  char lib_directory[PATH_CAPACITY];
+  char runtime_directory[PATH_CAPACITY];
 
-  if (sshpath) {
-    strcpy_s(shen_scheme_home_path, PATH_MAX, sshpath);
+  if (runtime == NULL || strcmp(runtime, "full") == 0) {
+    petite_runtime = 0;
+  } else if (strcmp(runtime, "petite") == 0) {
+    petite_runtime = 1;
   } else {
-#if defined(_WIN32)
-    HMODULE hModule = GetModuleHandle(NULL);
-    GetModuleFileName(hModule, shen_scheme_home_path, PATH_MAX);
-#elif defined(__APPLE__)
-    uint32_t bufsize = PATH_MAX;
-    _NSGetExecutablePath(tmpbuf, &bufsize);
-    realpath(tmpbuf, shen_scheme_home_path);
-#else
-    readlink("/proc/self/exe", shen_scheme_home_path, PATH_MAX);
-#endif
-    for (int slashes = 2; slashes > 0; --slashes) {
-      for (size_t i = strlen(shen_scheme_home_path); i >=0; --i) {
-        if (shen_scheme_home_path[i] == PATH_SEPARATOR[0]) {
-          shen_scheme_home_path[i] = '\0';
-          break;
-        }
-      }
-    }
-    strncat(shen_scheme_home_path, "/lib/shen-scheme",
-            PATH_MAX - strlen(shen_scheme_home_path) - 1);
+    fail("SHEN_SCHEME_RUNTIME must be either \"full\" or \"petite\"", runtime);
   }
 
-  if (ssbfpath) {
-    strcpy_s(shen_scheme_bootfile_path, PATH_MAX, ssbfpath);
+  if (home != NULL) {
+    if (home[0] == '\0')
+      fail("SHEN_SCHEME_HOME must not be empty", NULL);
+    copy_path(shen_scheme_home_path, home);
   } else {
-    snprintf(shen_scheme_bootfile_path, PATH_MAX, "%s%sshen.boot",
-             shen_scheme_home_path,PATH_SEPARATOR);
+    executable_path(executable);
+    parent_path(executable);
+    parent_path(executable);
+    join_path(lib_directory, executable, "lib");
+    join_path(shen_scheme_home_path, lib_directory, "shen-scheme");
   }
+
+  join_path(petite_boot_path, shen_scheme_home_path, "petite.boot");
+  join_path(scheme_boot_path, shen_scheme_home_path, "scheme.boot");
+  join_path(runtime_directory, shen_scheme_home_path, "shen-scheme");
+  join_path(runtime_object_path, runtime_directory, "runtime.so");
+
+  FREE_ENV(home);
+  FREE_ENV(runtime);
+}
+
+static void validate_runtime_files(void) {
+  require_readable("cannot read petite.boot", petite_boot_path);
+  if (!petite_runtime)
+    require_readable("cannot read scheme.boot", scheme_boot_path);
+  require_readable("cannot read Shen/Scheme runtime object",
+                   runtime_object_path);
 }
 
 static const char *get_shen_scheme_home_path(void) {
@@ -80,25 +197,71 @@ static ptr buf_to_bytevector(const void *buf, size_t len) {
   return bv;
 }
 
-int main(int argc, char *argv[]) {
-  int status;
+static void load_program(const char *path) {
+  ptr program = Sstring_utf8(path, -1);
+
+  Slock_object(program);
+  Scall1(Stop_level_value(Sstring_to_symbol("load-program")), program);
+  Sunlock_object(program);
+}
+
+static int shen_scheme_main(int argc, char *argv[]) {
+  int index, status;
+  const char **scheme_argv;
 
   initialize_paths();
-
-  if (access(shen_scheme_bootfile_path, F_OK) == -1) {
-    fprintf(stderr, "ERROR: boot file '%s' doesn't exist or is not readable.\n",
-            shen_scheme_bootfile_path);
-    exit(1);
-  }
+  validate_runtime_files();
 
   Sscheme_init(NULL);
-  Sregister_boot_file(shen_scheme_bootfile_path);
+  Sregister_boot_file(petite_boot_path);
+  if (!petite_runtime)
+    Sregister_boot_file(scheme_boot_path);
   Sbuild_heap(NULL, NULL);
+
   Sforeign_symbol("get_shen_scheme_home_path", (void*)get_shen_scheme_home_path);
   Sforeign_symbol("scm_make_utf8_string", (void*)Sstring_utf8);
   Sforeign_symbol("scm_make_bytevector", (void*)buf_to_bytevector);
-  status = Sscheme_start(argc + 1, (const char**)argv - 1);
+  load_program(runtime_object_path);
+
+  scheme_argv = malloc((size_t)(argc + 2) * sizeof(*scheme_argv));
+  if (scheme_argv == NULL)
+    fail("cannot allocate the Scheme argument vector", NULL);
+  scheme_argv[0] = argv[0];
+  for (index = 0; index < argc; index++)
+    scheme_argv[index + 1] = argv[index];
+  scheme_argv[argc + 1] = NULL;
+
+  status = Sscheme_start(argc + 1, scheme_argv);
+  free(scheme_argv);
   Sscheme_deinit();
 
-  exit(status);
+  return status;
 }
+
+#if defined(_WIN32) && !defined(__MINGW32__)
+int wmain(int argc, wchar_t *wide_argv[], wchar_t *wide_envp[]) {
+  char **argv = malloc((size_t)(argc + 1) * sizeof(*argv));
+  int index, status;
+
+  (void)wide_envp;
+  if (argv == NULL)
+    fail("cannot allocate the UTF-8 argument vector", NULL);
+  for (index = 0; index < argc; index++) {
+    argv[index] = Swide_to_utf8(wide_argv[index]);
+    if (argv[index] == NULL)
+      fail("cannot convert a command-line argument to UTF-8", NULL);
+  }
+  argv[argc] = NULL;
+
+  status = shen_scheme_main(argc, argv);
+  for (index = 0; index < argc; index++)
+    free(argv[index]);
+  free(argv);
+
+  return status;
+}
+#else
+int main(int argc, char *argv[]) {
+  return shen_scheme_main(argc, argv);
+}
+#endif

--- a/scripts/bench-native-sealed.shen
+++ b/scripts/bench-native-sealed.shen
@@ -1,0 +1,64 @@
+\* Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(package native-bench
+ [compatible sealed native-bench-loop
+  shen-scheme.compile-file/emit/mode
+  shen-scheme.load-compiled]
+
+(define iterations
+  -> 20000000)
+
+(define warmup-iterations
+  -> 1000000)
+
+(define samples
+  -> 5)
+
+(define compile-load
+  Source Object Scheme Mode
+  -> (do (shen-scheme.compile-file/emit/mode Source Object Scheme Mode)
+         (shen-scheme.load-compiled Object)))
+
+(define workload
+  N -> (eval [native-bench-loop N 0]))
+
+(define time-sample
+  Label Sample -> (let Start (get-time run)
+                       Result (workload (iterations))
+                       End (get-time run)
+                       Elapsed (- End Start)
+                    (do (output "~A sample ~A: ~A seconds (result ~A)~%" Label Sample Elapsed Result)
+                        Elapsed)))
+
+(define run-samples
+  _ Sample Total -> [] where (> Sample Total)
+  Label Sample Total -> [(time-sample Label Sample) | (run-samples Label (+ Sample 1) Total)])
+
+(define best-time
+  [Time | Times] -> (best-time* Time Times))
+
+(define best-time*
+  Best [] -> Best
+  Best [Time | Times] -> (best-time* Time Times) where (< Time Best)
+  Best [_ | Times] -> (best-time* Best Times))
+
+(define run-one
+  Label Mode Object Scheme
+  -> (do (compile-load "tests/native/call-heavy.shen" Object Scheme Mode)
+         (output "~A warmup: ~A iterations~%" Label (warmup-iterations))
+         (workload (warmup-iterations))
+         (let Times (run-samples Label 1 (samples))
+              Best (best-time Times)
+           (do (output "~A best: ~A seconds~%" Label Best)
+               Best))))
+
+(define main
+  -> (do (output "native benchmark iterations/sample: ~A~%" (iterations))
+         (output "native benchmark samples: ~A~%" (samples))
+         (let Compatible (run-one "compatible" compatible "_build/native-bench/call-heavy-compatible.so" "_build/native-bench/call-heavy-compatible.scm")
+              Sealed (run-one "sealed" sealed "_build/native-bench/call-heavy-sealed.so" "_build/native-bench/call-heavy-sealed.scm")
+           (output "sealed speedup over compatible: ~A x~%" (/ Compatible Sealed)))))
+
+(main)
+)

--- a/scripts/build-runtime.ss
+++ b/scripts/build-runtime.ss
@@ -1,0 +1,34 @@
+(import (chezscheme))
+
+(define (true? value)
+  (if (member (string-downcase value) '("1" "true" "yes" "on")) #t #f))
+
+(define (usage)
+  (display
+    "usage: build-runtime.ss PROGRAM-SOURCE PROGRAM-OBJECT RUNTIME-SOURCE RUNTIME-OBJECT OUTPUT-OBJECT OPTIMIZE DEBUG INSPECTOR SOURCE-INFO\n"
+    (current-error-port))
+  (exit 2))
+
+(define args (cdr (command-line)))
+
+(unless (= (length args) 9)
+  (usage))
+
+(define (build-runtime program-source program-object runtime-source
+                       runtime-object output-object optimize debug
+                       inspector source-info)
+  (let ([root (path-parent (path-parent runtime-object))])
+    (parameterize ([optimize-level (string->number optimize)]
+                   [debug-level (string->number debug)]
+                   [generate-inspector-information (true? inspector)]
+                   [generate-procedure-source-information (true? source-info)]
+                   [compile-file-message #t])
+      (compile-file runtime-source runtime-object)
+      (parameterize ([library-directories
+                      (cons (cons root root) (library-directories))])
+        (compile-file program-source program-object))
+      (when (file-exists? output-object)
+        (delete-file output-object))
+      (concatenate-object-files output-object runtime-object program-object))))
+
+(apply build-runtime args)

--- a/scripts/build.shen
+++ b/scripts/build.shen
@@ -6,11 +6,10 @@
     (load "build.shen")
     (build program "shen-scheme.scm")
 
-  The call to `build` will generate Scheme code files in "compiled/*.scm",
-  and a "shen-scheme.scm" file containing a program or R6RS library definition.
-  All initialization code will be contained in a `shen-initialize`
-  function that has to be called to initialize the Shen environment
-  before using it.
+  The call to `build` generates Scheme code files in "compiled/*.scm",
+  "shen-scheme-runtime.ss", and a file containing a program or public R6RS
+  library definition.  The public library exports `initialize-shen`, which
+  must be called before using the Shen environment.
 
 *\
 
@@ -21,8 +20,30 @@
   ((foreign scm.) "(define-top-level-value kl:global/*property-vector* (make-parameter (kl:value '*property-vector*)))")
   (/. X ignore))
 
+(define source-rules
+  [{ | Rest] -> (source-rules-after-signature Rest)
+  Rules -> Rules)
+
+(define source-rules-after-signature
+  [} | Rules] -> Rules
+  [_ | Rest] -> (source-rules-after-signature Rest))
+
+(define source-rule-arity
+  [Arrow | _] -> 0 where (= Arrow (intern "->"))
+  [Arrow | _] -> 0 where (= Arrow (intern "<-"))
+  [_ | Rest] -> (+ 1 (source-rule-arity Rest)))
+
+(define register-source-arities
+  [] -> []
+  [[define Name | Rules] | Rest]
+  -> (do (update-lambda-table Name
+                              (source-rule-arity (source-rules Rules)))
+         (register-source-arities Rest))
+  [_ | Rest] -> (register-source-arities Rest))
+
 \\(load "kl/extension-factorise-defun.kl")
 \\(load "src/factorize-patterns.shen")
+(register-source-arities (read-file "src/compiler.shen"))
 (load "src/compiler.shen")
 
 (trap-error
@@ -61,6 +82,11 @@
       ["overrides"
        "shen-scheme-extensions"
        "compiler"
+       "native-source"
+       "native-codegen"
+       "native-modules"
+       "native-app"
+       "native-compiler"
        \\"factorize-patterns"
        ])
 
@@ -151,6 +177,20 @@
   [defun | _] -> true
   _ -> false)
 
+(define defun-name
+  [defun Name | _] -> Name)
+
+(define defines-later?
+  _ [] -> false
+  Name [[defun Name | _] | _] -> true
+  Name [_ | Rest] -> (defines-later? Name Rest))
+
+(define keep-last-defuns
+  [] -> []
+  [Defun | Rest] -> (keep-last-defuns Rest)
+      where (defines-later? (defun-name Defun) Rest)
+  [Defun | Rest] -> [Defun | (keep-last-defuns Rest)])
+
 \* R6RS libraries require that all defines show up before
    any other code. That means that all code in the Shen
    kernel that is not a function definition has to be
@@ -184,11 +224,12 @@
           Defuns (build.filter
                    (/. X (and (defun? X) (not (overidden? X))))
                    Kl)
-          Exports (map (function register-export) Defuns)
+          LastDefuns (keep-last-defuns Defuns)
+          Exports (map (function register-export) LastDefuns)
           Init (store-init-code (build.filter
                                   (/. X (and (cons? X) (not (defun? X))))
                                   Kl))
-          Scm (map (function compile-defun) Defuns)
+          Scm (map (function compile-defun) LastDefuns)
           ScmS (map (function sexp->string) Scm)
           P (pr Prelude Out)
           F (for-each (/. S (pr (make-string "~A~%~%" S) Out) ) ScmS)
@@ -198,12 +239,29 @@
   [define F | Rules] -> (shen.shendef->kldef F Rules)
   Code -> Code)
 
+\* Port sources are translated without being loaded into the generated
+   runtime, so derive their arity-table initialization from the defuns. *\
+(define arity-registrations
+  [] -> []
+  [[defun Name Args _] | Rest]
+  -> [[update-lambda-table Name (length Args)]
+      | (arity-registrations Rest)]
+  [_ | Rest] -> (arity-registrations Rest))
+
+(define register-port-source-arities
+  [] -> []
+  [File | Rest]
+  -> (do (register-source-arities
+          (read-file (@s "src/" File ".shen")))
+         (register-port-source-arities Rest)))
+
 (define compile-shen-file
   From To -> (let Out (open To out)
                   Shen (read-file From)
                   Kl (map (function make-kl-code) Shen)
+                  Code (append Kl (arity-registrations Kl))
                   F (for-each (/. S (pr (make-string "~R~%~%" S) Out) )
-                              Kl)
+                              Code)
                (close Out)))
 
 (define compile-init-code
@@ -218,9 +276,16 @@
 
 (define build
   As Filename
-  -> (do (compile-shen-file "src/compiler.shen" "kl/compiler.kl")
+  -> (do (register-port-source-arities
+          (value *shen-scheme-files*))
+         (compile-shen-file "src/compiler.shen" "kl/compiler.kl")
          \\(compile-shen-file "src/factorize-patterns.shen" "kl/factorize-patterns.kl")
          (compile-shen-file "src/overrides.shen" "kl/overrides.kl")
+         (compile-shen-file "src/native-source.shen" "kl/native-source.kl")
+         (compile-shen-file "src/native-codegen.shen" "kl/native-codegen.kl")
+         (compile-shen-file "src/native-modules.shen" "kl/native-modules.kl")
+         (compile-shen-file "src/native-app.shen" "kl/native-app.kl")
+         (compile-shen-file "src/native-compiler.shen" "kl/native-compiler.kl")
          (compile-shen-file "src/shen-scheme-extensions.shen" "kl/shen-scheme-extensions.kl")
          (for-each (/. F (compile-kl-file
                           (shen-scheme-license)
@@ -249,9 +314,57 @@
                        " kl:global/" (str Name) ")c#10;"
                        (globals-register Rest)))
 
-(define loader-body
-  -> (@s
-"(import (chezscheme))
+(define runtime-primitive-exports
+  -> [register-globals
+      (prefix-fn _scm.assert-boolean)
+      (prefix-fn intern)
+      (prefix-fn str)
+      (prefix-fn set)
+      (prefix-fn value)
+      (prefix-fn error-to-string)
+      (prefix-fn =)
+      (prefix-fn eval-kl)
+      (prefix-fn open)
+      (prefix-fn close)
+      (prefix-fn write-byte)
+      (prefix-fn read-byte)
+      (prefix-fn get-time)
+      non-rational-/
+      value/or
+      get/or
+      <-address/or
+      <-vector/or
+      make-equal-hashtable
+      hashtable-fold
+      read-file-as-bytelist
+      read-file-as-string
+      shen-scheme-native-load-init?
+      error-location
+      analyse-symbol?])
+
+(define runtime-global-exports
+  -> (map (function _scm.prefix-global) (value _scm.*static-globals*)))
+
+(define runtime-exports
+  Names -> (append (runtime-primitive-exports)
+                   (runtime-global-exports)
+                   Names))
+
+(set *runtime-library-file* "shen-scheme-runtime.ss")
+
+(define runtime-library-definition
+  Names -> (@s
+";; Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.
+;; BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause
+
+
+(library (shen-scheme runtime)
+  "
+
+(sexp->string [export | (runtime-exports Names)])
+
+"
+  (import (chezscheme))
 
 "
 
@@ -264,6 +377,14 @@
 
 ")
 
+(define get-shen-scheme-home-path
+  (let ((proc #f))
+    (lambda ()
+      (unless proc
+        (set! proc
+          (foreign-procedure c#34;get_shen_scheme_home_pathc#34; () string)))
+      (proc))))
+
 (include c#34;src/chez-prelude.scmc#34;)
 (include c#34;src/primitives.scmc#34;)
 
@@ -271,6 +392,11 @@
 (include c#34;compiled/shen-scheme-extensions.scmc#34;)
 
 (include c#34;compiled/compiler.scmc#34;)
+(include c#34;compiled/native-source.scmc#34;)
+(include c#34;compiled/native-codegen.scmc#34;)
+(include c#34;compiled/native-modules.scmc#34;)
+(include c#34;compiled/native-app.scmc#34;)
+(include c#34;compiled/native-compiler.scmc#34;)
 ;(include c#34;compiled/factorize-patterns.scmc#34;)
 (include c#34;compiled/toplevel.scmc#34;)
 (include c#34;compiled/core.scmc#34;)
@@ -294,17 +420,30 @@
 ;; (include c#34;compiled/extension-factorise-defun.scmc#34;)
 ;; (include c#34;compiled/extension-programmable-pattern-matching.scmc#34;)
 
+)
+"))
+
+(define loader-body
+  -> "
+(import (chezscheme))
+(import (shen-scheme runtime))
+
 (define initialize-shen
   (let ((initialized #f))
     (lambda ()
       (if (not initialized)
           (begin
-            (define-top-level-value 'get-shen-scheme-home-path (foreign-procedure c#34;get_shen_scheme_home_pathc#34; () string))
             (include c#34;src/version.scmc#34;)
             (include c#34;src/init.scmc#34;)
             (include c#34;compiled/shen-scheme-init.scmc#34;)
             (set! initialized #t))))))
-"))
+")
+
+(define library-compatibility-body
+  -> "
+(define kl:shen.quiet-load kl:shen.x.launcher.quiet-load)
+(define kl:shen.run-shen kl:shen-scheme.run-shen)
+")
 
 (define write-string-to-file
   Body File -> (let Out (open File out)
@@ -312,12 +451,20 @@
                  (close Out)))
 
 (define compile-shen-as
-  library Filename -> (write-string-to-file
-                       (library-definition (value *functions*))
-                       Filename)
-  program Filename -> (write-string-to-file
-                       (program-definition)
-                       Filename))
+  library Filename -> (do
+                       (write-string-to-file
+                        (runtime-library-definition (value *functions*))
+                        (value *runtime-library-file*))
+                       (write-string-to-file
+                        (library-definition (value *functions*))
+                        Filename))
+  program Filename -> (do
+                       (write-string-to-file
+                        (runtime-library-definition (value *functions*))
+                        (value *runtime-library-file*))
+                       (write-string-to-file
+                        (program-definition)
+                        Filename)))
 
 (define initialization-body
   -> "(suppress-greeting #t)
@@ -333,8 +480,6 @@
                   (shen-scheme-license)
                   (loader-body)
                   (initialization-body)))
-
-\* library-definition is unused for now *\
 
 (define library-definition
   Names -> (let Exports [export initialize-shen
@@ -354,10 +499,11 @@
                                 (prefix-fn shen.quiet-load)
                                 (prefix-fn shen.run-shen)
                                 | Names]
-             (make-string "~A~%(library (shen)~%  ~R~%  ~A)"
+             (make-string "~A~%(library (shen)~%  ~A~%  ~A~%~A)"
                           (shen-scheme-license)
-                          Exports
-                          (loader-body))))
+                          (sexp->string Exports)
+                          (loader-body)
+                          (library-compatibility-body))))
 
 (define shen-license
   -> ";; Copyright (c) 2015, Mark Tarver

--- a/scripts/check-build-library.ss
+++ b/scripts/check-build-library.ss
@@ -1,0 +1,52 @@
+(import (chezscheme))
+
+(define root "_build/build-library-tests")
+(define public-source "_build/shen-library-test.ss")
+(define public-object (string-append root "/shen.so"))
+(define runtime-source "_build/shen-runtime-library-test.ss")
+(define runtime-directory (string-append root "/shen-scheme"))
+(define runtime-object (string-append root "/shen-scheme/runtime.so"))
+
+(define (assert-procedure label value)
+  (unless (procedure? value)
+    (error 'check-build-library "~a is not a procedure" label))
+  (printf "[OK]    ~a\n" label))
+
+(define (assert-same label expected actual)
+  (unless (eq? expected actual)
+    (error 'check-build-library "~a does not preserve its implementation" label))
+  (printf "[OK]    ~a\n" label))
+
+(unless (file-exists? root)
+  (mkdir root))
+(unless (file-exists? runtime-directory)
+  (mkdir runtime-directory))
+
+(parameterize ([optimize-level 0]
+               [compile-file-message #t]
+               [library-directories
+                (cons (cons root root) (library-directories))])
+  (compile-file runtime-source runtime-object)
+  (compile-file public-source public-object)
+  (let ([shen (environment '(shen))])
+    ;; The standalone Chez executable does not export the
+    ;; get_shen_scheme_home_path C symbol used during initialization.  Importing
+    ;; the complete generated library and checking the initializer binding
+    ;; validates the wrapper without invoking that host-specific callback.
+    (assert-procedure
+     "public library exports initialize-shen"
+     (eval 'initialize-shen shen))
+    (assert-procedure
+     "public library preserves shen.quiet-load"
+     (eval 'kl:shen.quiet-load shen))
+    (assert-procedure
+     "public library preserves shen.run-shen"
+     (eval 'kl:shen.run-shen shen))
+    (assert-same
+     "shen.quiet-load compatibility alias"
+     (eval 'kl:shen.x.launcher.quiet-load shen)
+     (eval 'kl:shen.quiet-load shen))
+    (assert-same
+     "shen.run-shen compatibility alias"
+     (eval 'kl:shen-scheme.run-shen shen)
+     (eval 'kl:shen.run-shen shen))))

--- a/scripts/check-runtime-object.ss
+++ b/scripts/check-runtime-object.ss
@@ -1,0 +1,20 @@
+(import (chezscheme))
+
+(define args (cdr (command-line)))
+
+(unless (= (length args) 1)
+  (display
+    "usage: check-runtime-object.ss LIBRARY-DIRECTORY\n"
+    (current-error-port))
+  (exit 2))
+
+(define root (car args))
+
+(parameterize ([library-directories
+                (cons (cons root root) (library-directories))])
+  (let* ([runtime (environment '(shen-scheme runtime))]
+         [run-shen (eval 'kl:shen-scheme.run-shen runtime)])
+    (unless (procedure? run-shen)
+      (error 'check-runtime-object
+             "the composite runtime does not export shen-scheme.run-shen"))
+    (printf "[OK]    composite runtime is importable\n")))

--- a/scripts/do-build.shen
+++ b/scripts/do-build.shen
@@ -19,6 +19,31 @@
 
 )
 
+(define bootstrap.source-rules
+  [{ | Rest] -> (bootstrap.source-rules-after-signature Rest)
+  Rules -> Rules)
+
+(define bootstrap.source-rules-after-signature
+  [} | Rules] -> Rules
+  [_ | Rest] -> (bootstrap.source-rules-after-signature Rest))
+
+(define bootstrap.source-rule-arity
+  [Arrow | _] -> 0 where (= Arrow (intern "->"))
+  [Arrow | _] -> 0 where (= Arrow (intern "<-"))
+  [_ | Rest] -> (+ 1 (bootstrap.source-rule-arity Rest)))
+
+(define bootstrap.register-source-arities
+  [] -> []
+  [[define Name | Rules] | Rest]
+  -> (do (update-lambda-table
+          Name
+          (bootstrap.source-rule-arity
+           (bootstrap.source-rules Rules)))
+         (bootstrap.register-source-arities Rest))
+  [_ | Rest] -> (bootstrap.register-source-arities Rest))
+
+(bootstrap.register-source-arities (read-file "src/compiler.shen"))
+
 (load "scripts/build.shen")
 
 (build program "shen-scheme.scm")

--- a/scripts/run-build-library-tests.shen
+++ b/scripts/run-build-library-tests.shen
@@ -1,0 +1,53 @@
+\* Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(load "scripts/build.shen")
+
+(define build-library-test.assert-equal
+  Label Expected Expected -> (pr (make-string "[OK]    ~A~%" Label))
+  Label Expected Actual -> (error "build library test failed: ~A expected ~R, got ~R~%"
+                                  Label Expected Actual))
+
+(define build-library-test.assert-contains
+  Label Needle String -> (build-library-test.assert-equal
+                          Label
+                          true
+                          (string.infix? Needle String)))
+
+(define build-library-test.run
+  -> (let Public "_build/shen-library-test.ss"
+          Runtime "_build/shen-runtime-library-test.ss"
+       (do
+         (shen-scheme.delete-file-if-exists Public)
+         (shen-scheme.delete-file-if-exists Runtime)
+         (set *runtime-library-file* Runtime)
+         (build library Public)
+         (let PublicBody (read-file-as-string Public)
+              RuntimeBody (read-file-as-string Runtime)
+           (do
+             (build-library-test.assert-contains
+              "library mode emits public Shen library"
+              "(library (shen)"
+              PublicBody)
+             (build-library-test.assert-contains
+              "public library exports initialize-shen"
+              "(export initialize-shen"
+              PublicBody)
+             (build-library-test.assert-contains
+              "public library imports the runtime"
+              "(import (shen-scheme runtime))"
+              PublicBody)
+             (build-library-test.assert-contains
+              "public library preserves quiet-load"
+              "(define kl:shen.quiet-load kl:shen.x.launcher.quiet-load)"
+              PublicBody)
+             (build-library-test.assert-contains
+              "public library preserves run-shen"
+              "(define kl:shen.run-shen kl:shen-scheme.run-shen)"
+              PublicBody)
+             (build-library-test.assert-contains
+              "library mode emits companion runtime library"
+              "(library (shen-scheme runtime)"
+              RuntimeBody))))))
+
+(build-library-test.run)

--- a/scripts/run-compiler-tests.shen
+++ b/scripts/run-compiler-tests.shen
@@ -17,7 +17,8 @@
 
 (define assert-equal-h
   Exp X X -> (pr (make-string "[OK]    ~A = ~R ~%" Exp X))
-  Exp X Y -> (pr (make-string "[ERROR] ~A = ~R ~%  got ~R~%" Exp Y X)))
+  Exp X Y -> (simple-error
+              (make-string "[ERROR] ~A = ~R ~%  got ~R~%" Exp Y X)))
 
 (define assert-equal
   Exp X Y -> (assert-equal-h Exp X (subst-vars X Y)))
@@ -34,5 +35,17 @@
 (define quiet-load
   File -> (let Contents (read-file File)
             (map (/. X (eval X)) Contents)))
+
+(assert-equal "(arity _scm.kl->scheme)"
+              (arity _scm.kl->scheme)
+              1)
+
+(assert-equal "(arity shen-scheme.profile-help-text)"
+              (arity shen-scheme.profile-help-text)
+              0)
+
+(assert-equal "(arity shen-scheme.run-shen)"
+              (arity shen-scheme.run-shen)
+              1)
 
 (quiet-load "tests/compiler-tests.shen")

--- a/scripts/run-external-runtime-tests.shen
+++ b/scripts/run-external-runtime-tests.shen
@@ -1,0 +1,83 @@
+\* Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(define external-runtime-test.assert-equal
+  L X X -> (pr (make-string "[OK]    ~A~%" L))
+  L X Y -> (error "external runtime test failed: ~A expected ~R, got ~R~%"
+                  L X Y))
+
+(define external-runtime-test.assert-app
+  O -> (do
+         (shen-scheme.load-compiled O)
+         (external-runtime-test.assert-equal
+          "external runtime runs app initializers"
+          [1 12]
+          (value *native-app-init-events*))
+         (external-runtime-test.assert-equal
+          "external runtime calls app entry point"
+          42
+          (eval [native-app-main 31]))
+         (external-runtime-test.assert-equal
+          "external runtime calls app helper"
+          42
+          (eval [native-app-direct 41]))
+         (external-runtime-test.assert-equal
+          "external runtime calls runtime global"
+          3
+          (eval [native-app-length [cons 1 [cons 2 [cons 3 []]]]]))
+         (external-runtime-test.assert-equal
+          "external runtime uses absvector fallback"
+          true
+          (eval [native-app-absvector?]))
+         (external-runtime-test.assert-equal
+          "external runtime uses generic equality fallback"
+          true
+          (eval [native-app-list-equal?]))
+         (external-runtime-test.assert-equal
+          "external runtime uses static runtime global"
+          true
+          (eval [native-app-sysfunc?]))))
+
+(define external-runtime-test.full
+  App O -> (do
+             (external-runtime-test.assert-app App)
+             (shen-scheme.delete-file-if-exists O)
+             (shen-scheme.compile-file "tests/native/simple.shen" O)
+             (external-runtime-test.assert-equal
+              "full external runtime emits native object"
+              true
+              (shen-scheme.file-exists? O))
+             (shen-scheme.load-compiled O)
+             (external-runtime-test.assert-equal
+              "full external runtime compiles and loads native source"
+              [5 6]
+              (eval [native-test-map-inc
+                     [cons 4 [cons 5 []]]]))))
+
+(define external-runtime-test.petite
+  App O -> (let R (do
+                    (external-runtime-test.assert-app App)
+                    (shen-scheme.delete-file-if-exists O)
+                    (trap-error
+                     (do
+                       (shen-scheme.compile-file "tests/native/simple.shen" O)
+                       unexpected-success)
+                     (/. E (error-to-string E))))
+            (do
+              (external-runtime-test.assert-equal
+               "Petite external runtime has no compiler"
+               "compile package is not loaded"
+               R)
+              (external-runtime-test.assert-equal
+               "Petite external runtime emits no native object"
+               false
+               (shen-scheme.file-exists? O)))))
+
+(define external-runtime-test.run
+  [_ "full" App O] -> (external-runtime-test.full App O)
+  [_ "petite" App O] -> (external-runtime-test.petite App O)
+  X -> (error
+        "usage: run-external-runtime-tests.shen full|petite APP OBJECT; got ~S~%"
+        X))
+
+(external-runtime-test.run (value *argv*))

--- a/scripts/run-native-core-regression-tests.shen
+++ b/scripts/run-native-core-regression-tests.shen
@@ -1,0 +1,229 @@
+\* Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(define native-test.run-core-regressions
+  -> (let Dir "_build/native-tests"
+          ForwardCaller "_build/native-tests/core-forward-caller.shen"
+          ForwardTarget "_build/native-tests/core-forward-target.shen"
+          ForwardCompatible "_build/native-tests/core-forward-compatible.shenmod"
+          ForwardSealed "_build/native-tests/core-forward-sealed.shenmod"
+          Duplicate "_build/native-tests/core-duplicate.shen"
+          DuplicateModule "_build/native-tests/core-duplicate.shenmod"
+          ArityBase "_build/native-tests/core-arity-base.shen"
+          ArityChanged "_build/native-tests/core-arity-changed.shen"
+          Package "_build/native-tests/core-package.shen"
+          PackageChain "_build/native-tests/core-package-chain.shen"
+          SystemDefinition "_build/native-tests/core-system-definition.shen"
+          Macro "_build/native-tests/core-macro.shen"
+          Assert (/. L E A (native-test.assert-equal L E A))
+       (do
+         (native-test.write-file
+          ForwardCaller
+          "(define native-core-forward-call
+  X -> (native-core-forward-target X 2))
+")
+         (native-test.write-file
+          ForwardTarget
+          "(define native-core-forward-target
+  X Y -> (+ X Y))
+")
+         (native-test.write-file
+          ForwardCompatible
+          (make-string "(shen.aot.module
+  (name native.test.core-forward-compatible)
+  (mode compatible)
+  (sources ~S ~S))
+"
+                       ForwardCaller ForwardTarget))
+         (native-test.write-file
+          ForwardSealed
+          (make-string "(shen.aot.module
+  (name native.test.core-forward-sealed)
+  (mode sealed)
+  (exports native-core-forward-call)
+  (sources ~S ~S))
+"
+                       ForwardCaller ForwardTarget))
+         (shen-scheme.compile-module
+          ForwardCompatible
+          "_build/native-tests/core-forward-compatible.so")
+         (shen-scheme.load-compiled
+          "_build/native-tests/core-forward-compatible.so")
+         (Assert "compatible source set sees later arity"
+                 42
+                 (eval [native-core-forward-call 40]))
+         (shen-scheme.compile-module
+          ForwardSealed
+          "_build/native-tests/core-forward-sealed.so")
+         (shen-scheme.load-compiled
+          "_build/native-tests/core-forward-sealed.so")
+         (Assert "sealed source set sees later arity"
+                 42
+                 (eval [native-core-forward-call 40]))
+
+         (native-test.write-file
+         Duplicate
+          "(define native-core-duplicate
+  { number --> number }
+  X -> (+ X 1))
+
+(define native-core-duplicate
+  X -> (+ X 2))
+
+(define native-core-duplicate-call
+  X -> (native-core-duplicate X))
+")
+         (shen-scheme.compile-file/mode
+          Duplicate
+          "_build/native-tests/core-duplicate-sealed.so"
+          sealed)
+         (shen-scheme.load-compiled
+          "_build/native-tests/core-duplicate-sealed.so")
+         (Assert "sealed duplicate definition keeps last"
+                 7
+                 (eval [native-core-duplicate-call 5]))
+         (Assert "sealed duplicate preserves earlier signature"
+                 true
+                 (not (= []
+                         (assoc native-core-duplicate
+                                (value shen.*sigf*)))))
+         (native-test.write-file
+          DuplicateModule
+          (make-string "(shen.aot.module
+  (name native.test.core-duplicate)
+  (mode sealed)
+  (exports native-core-duplicate-call)
+  (sources ~S))
+"
+                       Duplicate))
+         (shen-scheme.build-module-app
+          DuplicateModule
+          Dir
+          "_build/native-tests/core-duplicate-app.so")
+         (shen-scheme.load-compiled
+          "_build/native-tests/core-duplicate-app.so")
+         (Assert "module app duplicate definition keeps last"
+                 7
+                 (eval [native-core-duplicate-call 5]))
+
+         (native-test.write-file
+          ArityBase
+          "(define native-core-arity
+  X Y -> (+ X Y))
+")
+         (native-test.write-file
+          ArityChanged
+          "(define native-core-arity
+  X -> (+ X 100))
+")
+         (load ArityBase)
+         (let Before (arity native-core-arity)
+           (do
+             (shen-scheme.compile-file
+              ArityChanged
+              "_build/native-tests/core-arity-changed.so")
+             (Assert "compile-only preserves live arity"
+                     Before
+                     (arity native-core-arity))
+             (Assert "compile-only preserves live function calls"
+                     42
+                     (eval [native-core-arity 40 2]))))
+
+         (native-test.write-file
+          Package
+          "(package native.core.regression.pkg
+  [native-core-package-public]
+
+(define native-core-package-public
+  X -> X))
+")
+         (Assert "compile package starts unregistered"
+                 false
+                 (package? native.core.regression.pkg))
+         (shen-scheme.compile-file
+          Package
+          "_build/native-tests/core-package.so")
+         (Assert "compile-only leaves package registry unchanged"
+                 false
+                 (package? native.core.regression.pkg))
+
+         (native-test.write-file
+          PackageChain
+          "(package native.core.regression.first
+  [native-core-package-first]
+
+(define native-core-package-first
+  X -> (+ X 1)))
+
+(package native.core.regression.second
+  (external native.core.regression.first)
+
+(define second-private
+  X -> (native-core-package-first X)))
+")
+         (shen-scheme.compile-file
+          PackageChain
+          "_build/native-tests/core-package-chain.so")
+         (Assert "compile package chain leaves first package unregistered"
+                 false
+                 (package? native.core.regression.first))
+         (Assert "compile package chain leaves second package unregistered"
+                 false
+                 (package? native.core.regression.second))
+         (shen-scheme.load-compiled
+          "_build/native-tests/core-package-chain.so")
+         (Assert "later package sees earlier package externals"
+                 42
+                 (eval [native.core.regression.second.second-private 41]))
+
+         (native-test.write-file
+          SystemDefinition
+          "(define +
+  X Y -> X)
+")
+         (Assert "native compile rejects same-arity system definition"
+                 failed
+                 (trap-error
+                  (shen-scheme.compile-file
+                   SystemDefinition
+                   "_build/native-tests/core-system-definition.so")
+                  (/. E failed)))
+
+         (native-test.write-file
+          Macro
+          "(defmacro native-core-synonym-macro
+  [native-core-synonym] -> [synonyms native-core-count number])
+
+(native-core-synonym)
+")
+         (let Macros (value *macros*)
+              SigF (value shen.*sigf*)
+              Synonyms (value shen.*synonyms*)
+              Demod (value shen.*demodulation-function*)
+              Datatypes (value shen.*datatypes*)
+              AllDatatypes (value shen.*alldatatypes*)
+              UserDefs (value shen.*userdefs*)
+           (do
+             (shen-scheme.compile-file
+              Macro
+              "_build/native-tests/core-macro.so")
+             (Assert "compile-only restores macros"
+                     Macros (value *macros*))
+             (Assert "compile-only restores declarations"
+                     SigF (value shen.*sigf*))
+             (Assert "compile-only restores synonyms"
+                     Synonyms (value shen.*synonyms*))
+             (Assert "compile-only restores type demodulation"
+                     Demod (value shen.*demodulation-function*))
+             (Assert "compile-only restores datatypes"
+                     Datatypes (value shen.*datatypes*))
+             (Assert "compile-only restores all datatypes"
+                     AllDatatypes (value shen.*alldatatypes*))
+             (Assert "compile-only restores user definitions"
+                     UserDefs (value shen.*userdefs*))))
+         (shen-scheme.load-compiled
+          "_build/native-tests/core-macro.so")
+         (Assert "macro-generated synonym is replayed"
+                 true
+                 (element? native-core-count
+                           (value shen.*synonyms*))))))

--- a/scripts/run-native-module-regression-tests.shen
+++ b/scripts/run-native-module-regression-tests.shen
@@ -1,0 +1,126 @@
+\* Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(define native-test.run-module-dependency-regressions
+  -> (let Dir "_build/native-tests"
+          BSource "_build/native-tests/module-precedence-b.shen"
+          ASource "_build/native-tests/module-precedence-a.shen"
+          MainSource "_build/native-tests/module-precedence-main.shen"
+          BDeclaration "_build/native-tests/native.test.precedence-b.shenmod"
+          ADeclaration "_build/native-tests/native.test.precedence-a.shenmod"
+          MainDeclaration "_build/native-tests/native.test.precedence-main.shenmod"
+          BObject "_build/native-tests/native.test.precedence-b.so"
+          AObject "_build/native-tests/native.test.precedence-a.so"
+          MainObject "_build/native-tests/native.test.precedence-main.so"
+          AppObject "_build/native-tests/module-precedence-app.so"
+          Assert (/. Label Expected Actual
+                    (native-test.assert-equal Label Expected Actual))
+       (do
+         (native-test.write-file
+          BSource
+          "(set *native-module-regression-effects*
+     (+ (value *native-module-regression-effects*) 1))
+
+(declare native-module-regression-shared
+         [number --> number --> number])
+
+(define native-module-regression-shared
+  X Y -> (+ X Y))
+
+(defmacro native-module-regression-call-shared-macro
+  [native-module-regression-call-shared X]
+  -> [native-module-regression-shared X 2])
+")
+         (native-test.write-file
+          ASource
+          "(define native-module-regression-shared
+  X -> (+ X 100))
+")
+         (native-test.write-file
+          MainSource
+          "(define native-module-regression-main
+  X -> (native-module-regression-call-shared X))
+")
+         (native-test.write-file
+          BDeclaration
+          (make-string "(shen.aot.module
+  (name native.test.precedence-b)
+  (mode sealed)
+  (exports native-module-regression-shared)
+  (sources ~S))
+"
+                       BSource))
+         (native-test.write-file
+          ADeclaration
+          (make-string "(shen.aot.module
+  (name native.test.precedence-a)
+  (mode sealed)
+  (requires native.test.precedence-b)
+  (exports native-module-regression-shared)
+  (sources ~S))
+"
+                       ASource))
+         (native-test.write-file
+          MainDeclaration
+          (make-string "(shen.aot.module
+  (name native.test.precedence-main)
+  (mode sealed)
+  (requires native.test.precedence-a native.test.precedence-b)
+  (exports native-module-regression-main)
+  (sources ~S))
+"
+                       MainSource))
+         (native-test.delete-file-if-exists BObject)
+         (native-test.delete-file-if-exists AObject)
+         (native-test.delete-file-if-exists MainObject)
+         (native-test.delete-file-if-exists AppObject)
+         (set *native-module-regression-effects* 0)
+         (load ASource)
+         (let InitialArity (arity native-module-regression-shared)
+              InitialSignature (assoc native-module-regression-shared
+                                      (value shen.*sigf*))
+           (do
+             (shen-scheme.compile-module/in-dir
+              ADeclaration AObject Dir)
+             (Assert "module compile needs no dependency object"
+                     false
+                     (shen-scheme.file-exists? BObject))
+             (Assert "module compile skips dependency initializer"
+                     0
+                     (value *native-module-regression-effects*))
+             (Assert "module compile leaves live dependency function"
+                     140
+                     (eval [native-module-regression-shared 40]))
+             (shen-scheme.compile-module BDeclaration BObject)
+             (shen-scheme.compile-module/in-dir
+              MainDeclaration MainObject Dir)
+             (Assert "module compile reapply skips dependency initializer"
+                     0
+                     (value *native-module-regression-effects*))
+             (Assert "module dependency arities stay compiler-local"
+                     InitialArity
+                     (arity native-module-regression-shared))
+             (Assert "module dependency signatures stay compiler-local"
+                     InitialSignature
+                     (assoc native-module-regression-shared
+                            (value shen.*sigf*)))
+             (Assert "module compile leaves live function binding"
+                     140
+                     (eval [native-module-regression-shared 40]))
+             (Assert "module app rejects ambiguous direct exports"
+                     failed
+                     (trap-error
+                      (shen-scheme.build-module-app
+                       MainDeclaration Dir AppObject)
+                      (/. E failed)))
+             (Assert "module app build skips source initializer"
+                     0
+                     (value *native-module-regression-effects*))
+             (set *native-module-regression-effects* 0)
+             (shen-scheme.load-module MainDeclaration Dir)
+             (Assert "module load does not repeat transitive initializer"
+                     1
+                     (value *native-module-regression-effects*))
+             (Assert "module compile uses later dependency metadata"
+                     42
+                     (eval [native-module-regression-main 40])))))))

--- a/scripts/run-native-tests.shen
+++ b/scripts/run-native-tests.shen
@@ -1,0 +1,1163 @@
+\* Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(define native-test.assert-equal
+  Label Expected Expected -> (pr (make-string "[OK]    ~A~%" Label))
+  Label Expected Actual -> (error "native test failed: ~A expected ~R, got ~R~%"
+                                  Label Expected Actual))
+
+(define native-test.contains-form?
+  X X -> true
+  X [Y | Ys] -> (if (native-test.contains-form? X Y)
+                    true
+                    (native-test.contains-form? X Ys))
+  _ _ -> false)
+
+(define native-test.unit-compiletime
+  [native-unit _ _ CT _] -> CT)
+
+(define native-test.compiletime-kind
+  [_ [quote [defmacro | _]]] -> defmacro
+  [_ [quote [synonyms | _]]] -> synonyms
+  [_ _ _] -> declare)
+
+(define native-test.assert-facade-arities
+  [] -> true
+  [[Function Expected] | Rest]
+  -> (do
+      (native-test.assert-equal
+       (make-string "native facade arity ~A" Function)
+       Expected
+       (arity Function))
+      (native-test.assert-facade-arities Rest)))
+
+(define native-test.assert-unprefixed-symbols
+  _ _ [] -> true
+  Label Forms [Name | Rest]
+  -> (let Expected (intern Name)
+          Prefixed (intern (@s "shen-scheme." Name))
+       (do
+         (native-test.assert-equal
+          (make-string "~A contains ~A" Label Expected)
+          true
+          (native-test.contains-form? Expected Forms))
+         (native-test.assert-equal
+          (make-string "~A omits package-prefixed ~A" Label Expected)
+          false
+          (native-test.contains-form? Prefixed Forms))
+         (native-test.assert-unprefixed-symbols Label Forms Rest))))
+
+(define native-test.write-file
+  File Body -> (let Out (open File out)
+                 (do (pr Body Out)
+                     (close Out))))
+
+(define native-test.delete-file-if-exists
+  File -> (shen-scheme.delete-file-if-exists File))
+
+(define native-test.module-lib-source
+  -> "(define native-module-helper
+  X -> (+ X 37))
+")
+
+(define native-test.module-main-source
+  -> "(define native-module-private
+  X -> (+ X 1000))
+
+(define native-module-main
+  X -> (native-module-helper X))
+")
+
+(define native-test.module-default-source
+  -> "(define native-module-default-main
+  X -> (+ X 1))
+")
+
+(define native-test.module-typed-source
+  -> "(define native-module-typed
+  { number --> number }
+  X -> (+ X 1))
+")
+
+(define native-test.module-runtime-only-source
+  -> "(define native-module-runtime-only
+  { number --> number }
+  X -> (+ X 1))
+")
+
+(define native-test.module-declared-source
+  -> "(declare native-module-declared [number --> number])
+
+(define native-module-declared
+  X -> (+ X 1))
+")
+
+(define native-test.module-runtime-only-declared-source
+  -> "(declare native-module-runtime-only-declared [number --> number])
+
+(define native-module-runtime-only-declared
+  X -> (+ X 1))
+")
+
+(define native-test.module-macro-source
+  -> "(defmacro native-module-twice-macro
+  [native-module-twice X] -> [* 2 X])
+")
+
+(define native-test.module-macro-user-source
+  -> "(define native-module-macro-user
+  X -> (native-module-twice X))
+")
+
+(define native-test.module-synonym-source
+  -> "(synonyms native-count number)
+")
+
+(define native-test.module-synonym-user-source
+  -> "(define native-module-synonym-user
+  { native-count --> native-count }
+  X -> (+ X 1))
+")
+
+(define native-test.module-datatype-source
+  -> "(datatype native-small
+  if (element? X [0 1])
+  ________________
+  X : native-small;)
+")
+
+(define native-test.module-datatype-user-source
+  -> "(define native-module-datatype-user
+  { number --> native-small }
+  _ -> 1)
+")
+
+(define native-test.prolog-source
+  -> "(defprolog native-prolog-nreverse
+  [] [] <--;
+  [X | Y] R <-- (native-prolog-nreverse Y RY) (native-prolog-nappend RY [X] R);)
+
+(defprolog native-prolog-nappend
+  [] X X <--;
+  [X | Y] Z [X | W] <-- (native-prolog-nappend Y Z W);)
+")
+
+(define native-test.module-source-kl-source
+  -> "(define native-module-source-kl
+  X -> (+ X 1))
+")
+
+(define native-test.module-no-source-kl-source
+  -> "(define native-module-no-source-kl
+  X -> (+ X 1))
+")
+
+(define native-test.module-required-source
+  -> "(define native-module-required-helper
+  X -> (+ X 10))
+")
+
+(define native-test.module-requirer-source
+  -> "(define native-module-requirer
+  X -> (native-module-required-helper X))
+")
+
+(define native-test.module-private-arity-source
+  -> "(define shen-scheme.native-compile-profile-options
+  X Y -> (= X Y))
+
+(define native-module-private-arity-export
+  X -> X)
+")
+
+(define native-test.module-private-arity-main-source
+  -> "(define native-module-private-arity-main
+  X -> (= (shen-scheme.native-compile-profile-options X)
+          [2 0 false false false]))
+")
+
+(define native-test.module-package-source
+  -> "(package native.test.dependency.pkg
+ [native-module-package-export]
+
+(define native-module-package-export
+  X -> (+ X 1))
+)
+")
+
+(define native-test.module-package-main-source
+  -> "(package native.test.package-main
+ (append [native-module-package-main] (external native.test.dependency.pkg))
+
+(define native-module-package-main
+  X -> (native-module-package-export X))
+)
+")
+
+(define native-test.module-app-base-source
+  -> "(set *native-module-app-init-events* [])
+
+(define native-module-app-private
+  X -> (+ X 1000))
+
+(define native-module-app-base
+  X -> (+ X 10))
+
+(set *native-module-app-init-events*
+     (append (value *native-module-app-init-events*)
+             [(native-module-app-base 0)]))
+")
+
+(define native-test.module-app-base-updated-source
+  -> "(define native-module-app-base
+  X -> (+ X 1000))
+")
+
+(define native-test.module-app-main-source
+  -> "(set *native-module-app-init-events*
+     (append (value *native-module-app-init-events*)
+             [(native-module-app-main 1)]))
+
+(define native-module-app-main
+  X -> (native-module-app-base X))
+")
+
+(define native-test.module-app-private-call-source
+  -> "(define native-module-app-private-probe
+  X -> (native-module-app-private X))
+")
+
+(define native-test.module-declaration-source
+  Lib Main -> (make-string "(shen.aot.module
+  (profile debug)
+  (exports native-module-main)
+  (sources ~S ~S)
+  (name native.test.module)
+  (mode sealed)
+  (metadata compiletime runtime))
+"
+                           Lib
+                           Main))
+
+(define native-test.module-default-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.defaults)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-typed-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.typed)
+  (mode sealed)
+  (exports native-module-typed)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-runtime-only-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.runtime-only)
+  (mode sealed)
+  (exports native-module-runtime-only)
+  (metadata runtime)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-declared-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.declared)
+  (mode sealed)
+  (exports native-module-declared)
+  (metadata runtime compiletime)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-runtime-only-declared-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.runtime-only-declared)
+  (mode sealed)
+  (exports native-module-runtime-only-declared)
+  (metadata runtime)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-compiletime-only-declaration-source
+  Name Source -> (make-string "(shen.aot.module
+  (name ~A)
+  (mode sealed)
+  (metadata compiletime)
+  (sources ~S))
+"
+                              Name
+                              Source))
+
+(define native-test.module-source-kl-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.source-kl)
+  (mode sealed)
+  (exports native-module-source-kl)
+  (metadata runtime source-kl)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-no-source-kl-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.no-source-kl)
+  (mode sealed)
+  (exports native-module-no-source-kl)
+  (metadata runtime compiletime)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-required-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.required)
+  (mode sealed)
+  (exports native-module-required-helper)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-requirer-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.requirer)
+  (mode sealed)
+  (requires native.test.required)
+  (exports native-module-requirer)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-private-arity-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.private-arity)
+  (mode sealed)
+  (exports native-module-private-arity-export)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-private-arity-main-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.private-arity-main)
+  (mode sealed)
+  (requires native.test.private-arity)
+  (exports native-module-private-arity-main)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-package-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.package)
+  (mode sealed)
+  (exports native-module-package-export)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-package-main-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.package-main)
+  (mode sealed)
+  (requires native.test.package)
+  (exports native-module-package-main)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-cycle-a-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.cycle-a)
+  (mode sealed)
+  (requires native.test.cycle-b)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-cycle-b-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.cycle-b)
+  (mode sealed)
+  (requires native.test.cycle-a)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-app-base-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.app-base)
+  (mode sealed)
+  (exports native-module-app-base)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-app-main-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.app-main)
+  (mode sealed)
+  (requires native.test.app-base)
+  (exports native-module-app-main)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-app-private-call-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.app-private-call)
+  (mode sealed)
+  (requires native.test.app-base)
+  (exports native-module-app-private-probe)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-app-missing-require-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.app-missing-require)
+  (mode sealed)
+  (requires native.test.app-missing)
+  (exports native-module-app-main)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-app-bad-export-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.app-bad-export)
+  (mode sealed)
+  (exports native-module-app-missing)
+  (sources ~S))
+"
+                         Source))
+
+(define native-test.module-bad-declaration-source
+  Source -> (make-string "(shen.aot.module
+  (name native.test.bad)
+  (sources ~S)
+  (unknown-field true))
+"
+                         Source))
+
+(define native-test.compile-load
+  Source Object Scheme -> (do (shen-scheme.compile-file/emit Source Object Scheme)
+                              (shen-scheme.load-compiled Object)))
+
+(define native-test.compile-load/mode
+  Source Object Scheme Mode -> (do (shen-scheme.compile-file/emit/mode Source Object Scheme Mode)
+                                   (shen-scheme.load-compiled Object)))
+
+(define native-test.compile-load/direct
+  Source Object -> (do (shen-scheme.compile-file Source Object)
+                       (shen-scheme.load-compiled Object)))
+
+(define native-test.compile-load/direct/mode
+  Source Object Mode -> (do (shen-scheme.compile-file/mode Source Object Mode)
+                            (shen-scheme.load-compiled Object)))
+
+(define native-test.compile-load/direct/profile
+  Source Object Profile -> (do (shen-scheme.compile-file/profile Source Object Profile)
+                               (shen-scheme.load-compiled Object)))
+
+(define native-test.run-refactor-regressions
+  -> (let Source "tests/native/simple.shen"
+          CompatibleForms (shen-scheme.native-scheme-forms/mode
+                           Source
+                           compatible)
+          SealedForms (shen-scheme.native-scheme-forms/mode
+                       Source
+                       sealed)
+          AppName native-test-refactor-app
+          AppForms (append
+                    (shen-scheme.native-app-module-forms
+                     ["tests/native/app-lib.shen"
+                      "tests/native/app-main.shen"]
+                     AppName)
+                    (shen-scheme.native-app-install-forms 2))
+          DependencyMap (shen-scheme.native-module-app-required-visible-map
+                         [native.test.first native.test.second]
+                         [[module-app-map native.test.second 1
+                           [[native-test-shared native-test-second]]
+                           [[native-test-shared 2]]]
+                          [module-app-map native.test.first 0
+                           [[native-test-shared native-test-first]]
+                           [[native-test-shared 1]]]])
+          BadDependency
+          [module-declaration native.test.bad-dependency compatible
+           [Source] [] [native-test-add] [] release]
+       (do
+         (native-test.assert-facade-arities
+          [[shen-scheme.native-compile-profile-options 1]
+           [shen-scheme.native-compile-options 0]
+           [shen-scheme.compile-file 2]
+           [shen-scheme.compile-file/mode 3]
+           [shen-scheme.compile-file/profile 3]
+           [shen-scheme.compile-file/profile/mode 4]
+           [shen-scheme.compile-file/options 3]
+           [shen-scheme.compile-file/options/mode 4]
+           [shen-scheme.compile-file/emit 3]
+           [shen-scheme.compile-file/emit/mode 4]
+           [shen-scheme.compile-file/emit/profile 4]
+           [shen-scheme.compile-file/emit/profile/mode 5]
+           [shen-scheme.compile-file/emit/options 4]
+           [shen-scheme.compile-file/emit/options/mode 5]
+           [shen-scheme.compile-module 2]
+           [shen-scheme.compile-module/in-dir 3]
+           [shen-scheme.compile-module/emit 3]
+           [shen-scheme.compile-module/emit/in-dir 4]
+           [shen-scheme.load-module 2]
+           [shen-scheme.build-app 3]
+           [shen-scheme.build-app/wpo 3]
+           [shen-scheme.build-app/profile 4]
+           [shen-scheme.build-app/wpo/profile 4]
+           [shen-scheme.build-app/emit/options 6]
+           [shen-scheme.build-module-app 3]
+           [shen-scheme.build-module-app/wpo 3]
+           [shen-scheme.build-module-app/profile 4]
+           [shen-scheme.build-module-app/wpo/profile 4]
+           [shen-scheme.build-module-app/emit/options 6]
+           [shen-scheme.load-compiled 1]
+           [shen-scheme.delete-file-if-exists 1]
+           [shen-scheme.file-exists? 1]])
+         (native-test.assert-unprefixed-symbols
+          "compatible generated forms"
+          CompatibleForms
+          ["define"
+           "cond"
+           "quote"
+           "true"
+           "kl:update-lambda-table"])
+         (native-test.assert-unprefixed-symbols
+          "sealed generated forms"
+          SealedForms
+          ["module"
+           "import"
+           "define"
+           "cond"
+           "quote"
+           "true"
+           "define-top-level-value"
+           "kl:update-lambda-table"])
+         (native-test.assert-unprefixed-symbols
+          "app generated forms"
+          AppForms
+          ["module"
+           "define"
+           "quote"
+           "define-top-level-value"
+           "kl:update-lambda-table"])
+         (native-test.assert-equal
+          "module app later dependency precedence"
+          native-test-second
+          (_scm.with-native-context
+           app
+           DependencyMap
+           (freeze (_scm.native-local-name native-test-shared))))
+         (native-test.assert-equal
+          "compatible dependency explicit exports rejected"
+          failed
+          (trap-error
+           (shen-scheme.native-prepare-module/declaration*
+            BadDependency "" [] [])
+           (/. E failed)))
+         (native-test.assert-equal
+          "compatible direct name skips source key"
+          skip
+          (shen-scheme.native-module-name/mode
+           "_build/native-tests/missing-key-source.shen"
+           compatible))
+         (native-test.assert-equal
+          "compatible declaration name skips source key"
+          skip
+          (shen-scheme.native-module-declaration-module-name/mode
+           [module-declaration native.test.missing-key compatible
+            ["_build/native-tests/missing-key-source.shen"]
+            [] infer-all [] release]
+           compatible)))))
+
+(define native-test.run-private-dependency-arity
+  -> (let Dir "_build/native-tests"
+          DepSource "_build/native-tests/module-private-arity.shen"
+          MainSource "_build/native-tests/module-private-arity-main.shen"
+          DepDeclaration "_build/native-tests/native.test.private-arity.shenmod"
+          MainDeclaration "_build/native-tests/native.test.private-arity-main.shenmod"
+          Object "_build/native-tests/module-private-arity-main.so"
+          AppObject "_build/native-tests/module-private-arity-app.so"
+          Assert (/. L E A (native-test.assert-equal L E A))
+       (do
+         (native-test.write-file
+          DepSource
+          (native-test.module-private-arity-source))
+         (native-test.write-file
+          MainSource
+          (native-test.module-private-arity-main-source))
+         (native-test.write-file
+          DepDeclaration
+          (native-test.module-private-arity-declaration-source DepSource))
+         (native-test.write-file
+          MainDeclaration
+          (native-test.module-private-arity-main-declaration-source MainSource))
+         (shen-scheme.compile-module/in-dir MainDeclaration Object Dir)
+         (shen-scheme.load-compiled Object)
+         (Assert "module compile ignores private dependency arity"
+                 true
+                 (eval [native-module-private-arity-main release]))
+         (let Result (shen-scheme.build-module-app MainDeclaration Dir AppObject)
+           (do
+             (shen-scheme.load-compiled (hd Result))
+             (Assert "module app ignores private dependency arity"
+                     true
+                     (eval [native-module-private-arity-main release])))))))
+
+(define native-test.run-dependency-package-metadata
+  -> (let Dir "_build/native-tests"
+          DepSource "_build/native-tests/module-package.shen"
+          MainSource "_build/native-tests/module-package-main.shen"
+          DepDeclaration "_build/native-tests/native.test.package.shenmod"
+          MainDeclaration "_build/native-tests/native.test.package-main.shenmod"
+          Object "_build/native-tests/module-package-main.so"
+          AppObject "_build/native-tests/module-package-app.so"
+          Assert (/. L E A (native-test.assert-equal L E A))
+       (do
+         (native-test.write-file DepSource (native-test.module-package-source))
+         (native-test.write-file MainSource (native-test.module-package-main-source))
+         (native-test.write-file
+          DepDeclaration
+          (native-test.module-package-declaration-source DepSource))
+         (native-test.write-file
+          MainDeclaration
+          (native-test.module-package-main-declaration-source MainSource))
+         (shen-scheme.compile-module/in-dir MainDeclaration Object Dir)
+         (Assert "module compile preserves dependency package metadata"
+                 true
+                 (shen-scheme.file-exists? Object))
+         (let Result (shen-scheme.build-module-app MainDeclaration Dir AppObject)
+           (do
+             (shen-scheme.load-compiled (hd Result))
+             (Assert "module app preserves dependency package metadata"
+                     42
+                     (eval [native-module-package-main 41])))))))
+
+(define native-test.assert-simple
+  Prefix Add Inc Sumdown MapInc -> (let Assert (/. Label Expected Actual
+                                                 (native-test.assert-equal
+                                                   (@s Prefix Label)
+                                                   Expected
+                                                   Actual))
+                                     (do
+                                       (Assert " add" Add (eval [native-test-add 19 23]))
+                                       (Assert " inc" Inc (eval [native-test-inc 7]))
+                                       (Assert " recursion" Sumdown (eval [native-test-sumdown 5]))
+                                       (Assert " list" MapInc (eval [native-test-map-inc [cons 1 [cons 2 [cons 3 []]]]])))))
+
+(define native-test.run-compatible-redefinition
+  -> (do
+    (native-test.compile-load
+      "tests/native/redefinition-compatible.shen"
+      "_build/native-tests/redefinition-compatible.so"
+      "_build/native-tests/redefinition-compatible.scm")
+    (native-test.assert-equal "compatible before redefinition" 6 (eval [native-compatible-main 5]))
+    (load "tests/native/redefinition-compatible-updated.shen")
+    (native-test.assert-equal "compatible helper redefined" 105 (eval [native-compatible-helper 5]))
+    (native-test.assert-equal "compatible caller observes redefinition" 105 (eval [native-compatible-main 5]))))
+
+(define native-test.run-sealed-redefinition
+  -> (do
+    (native-test.compile-load/mode
+      "tests/native/redefinition-sealed.shen"
+      "_build/native-tests/redefinition-sealed.so"
+      "_build/native-tests/redefinition-sealed.scm"
+      sealed)
+    (native-test.assert-equal "sealed before redefinition" 6 (eval [native-sealed-main 5]))
+    (load "tests/native/redefinition-sealed-updated.shen")
+    (native-test.assert-equal "sealed helper redefined" 105 (eval [native-sealed-helper 5]))
+    (native-test.assert-equal "sealed caller keeps local helper" 6 (eval [native-sealed-main 5]))))
+
+(define native-test.run-direct-compile
+  -> (let DirectObject "_build/native-tests/api-direct.so"
+          DirectScheme (shen-scheme.native-scheme-path DirectObject)
+          SealedObject "_build/native-tests/api-direct-sealed.so"
+          SealedScheme (shen-scheme.native-scheme-path SealedObject)
+          Assert (/. Label Expected Actual
+                    (native-test.assert-equal Label Expected Actual))
+       (do
+         (native-test.delete-file-if-exists DirectScheme)
+         (native-test.delete-file-if-exists SealedScheme)
+         (native-test.compile-load/direct "tests/native/simple.shen" DirectObject)
+         (native-test.assert-simple "api direct load" 42 8 15 [2 3 4])
+         (Assert "api direct does not emit scheme" false
+                 (shen-scheme.file-exists? DirectScheme))
+         (native-test.compile-load/direct/mode "tests/native/redefinition-sealed.shen" SealedObject sealed)
+         (Assert "api direct sealed compile" 6 (eval [native-sealed-main 5]))
+         (Assert "api direct sealed does not emit scheme" false
+                 (shen-scheme.file-exists? SealedScheme)))))
+
+(define native-test.run-prolog
+  -> (let Source "_build/native-tests/prolog.shen"
+          Object "_build/native-tests/prolog-sealed.so"
+          Query "(prolog? (native-prolog-nreverse [1 2 3 4] X) (return X))"
+          Assert (/. Label Expected Actual
+                    (native-test.assert-equal Label Expected Actual))
+       (do
+         (native-test.write-file Source (native-test.prolog-source))
+         (native-test.compile-load/direct/mode Source Object sealed)
+         (Assert "sealed defprolog query"
+                 [4 3 2 1]
+                 (eval (hd (read-from-string Query)))))))
+
+(define native-test.run-package-effects
+  -> (let Source "tests/native/package-effects.shen"
+          Updated "tests/native/package-effects-updated.shen"
+          Compatible "_build/native-tests/package-effects-compatible.so"
+          Sealed "_build/native-tests/package-effects-sealed.so"
+          Assert (/. L E A (native-test.assert-equal L E A))
+       (do
+         (set *native-package-events* [compile])
+         (Assert "package compile-time metadata order"
+                 [defmacro synonyms declare]
+                 (map (function native-test.compiletime-kind)
+                      (native-test.unit-compiletime
+                       (shen-scheme.native-source->unit Source))))
+         (shen-scheme.compile-file Source Compatible)
+         (Assert "compatible effects deferred" [compile]
+                 (value *native-package-events*))
+         (shen-scheme.load-compiled Compatible)
+         (Assert "compatible package call" 12 (eval [native-package-main 5]))
+         (Assert "compatible package effect order" [41 2]
+                 (value *native-package-events*))
+         (Assert "compatible package external preserved" true
+                 (element? native-package-main (external native.test.pkg)))
+         (Assert "compatible package internal qualified" true
+                 (element? native.test.pkg.helper (internal native.test.pkg)))
+         (Assert "compatible package declaration qualified" true
+                 (not (= [] (assoc native.test.pkg.helper
+                                   (value shen.*sigf*)))))
+         (shen-scheme.compile-file/mode Source Sealed sealed)
+         (Assert "sealed effects deferred" [41 2]
+                 (value *native-package-events*))
+         (shen-scheme.load-compiled Sealed)
+         (Assert "sealed package effect order" [41 2]
+                 (eval [native-package-state]))
+         (load Updated)
+         (Assert "sealed qualified helper redefined" 1005
+                 (eval [native.test.pkg.helper 5]))
+         (Assert "sealed package caller keeps local helper" 12
+                 (eval [native-package-main 5])))))
+
+(define native-test.run-profiles
+  -> (let Assert (/. Label Expected Actual
+                    (native-test.assert-equal Label Expected Actual))
+          DebugOptions (shen-scheme.native-compile-profile-options debug)
+          WpoOptions (shen-scheme.native-compile-profile-options wpo)
+          UnsafeOptions (shen-scheme.native-compile-profile-options unsafe)
+          DebugObject "_build/native-tests/api-profile-debug.so"
+          DebugScheme (shen-scheme.native-scheme-path DebugObject)
+       (do
+         (Assert "profile release options" [2 0 false false false]
+                 (shen-scheme.native-compile-profile-options release))
+         (Assert "profile debug options" [2 2 true true false] DebugOptions)
+         (Assert "profile wpo options" [2 0 false false true] WpoOptions)
+         (Assert "profile unsafe options" [3 0 false false false] UnsafeOptions)
+         (Assert "profile string lookup" [2 2 true true false]
+                 (shen-scheme.native-compile-profile-options "debug"))
+         (Assert "profile wpo enables app WPO" true
+                 (shen-scheme.native-effective-wpo? WpoOptions false))
+         (Assert "explicit WPO composes with unsafe profile" true
+                 (shen-scheme.native-effective-wpo? UnsafeOptions true))
+         (native-test.delete-file-if-exists DebugScheme)
+         (native-test.compile-load/direct/profile
+          "tests/native/simple.shen"
+          DebugObject
+          debug)
+         (native-test.assert-simple "api debug profile load" 42 8 15 [2 3 4])
+         (Assert "api debug profile does not emit scheme"
+                 false
+                 (shen-scheme.file-exists? DebugScheme)))))
+
+(define native-test.run-module-declarations
+  -> (let Lib "_build/native-tests/module-lib.shen"
+          Main "_build/native-tests/module-main.shen"
+          DefaultSource "_build/native-tests/module-default.shen"
+          TypedSource "_build/native-tests/module-typed.shen"
+          RuntimeOnlySource "_build/native-tests/module-runtime-only.shen"
+          DeclaredSource "_build/native-tests/module-declared.shen"
+          RuntimeOnlyDeclaredSource "_build/native-tests/module-runtime-only-declared.shen"
+          MacroSource "_build/native-tests/module-macro.shen"
+          MacroUserSource "_build/native-tests/module-macro-user.shen"
+          SynonymSource "_build/native-tests/module-synonym.shen"
+          SynonymUserSource "_build/native-tests/module-synonym-user.shen"
+          DatatypeSource "_build/native-tests/module-datatype.shen"
+          DatatypeUserSource "_build/native-tests/module-datatype-user.shen"
+          SourceKlSource "_build/native-tests/module-source-kl.shen"
+          NoSourceKlSource "_build/native-tests/module-no-source-kl.shen"
+          RequiredSource "_build/native-tests/module-required.shen"
+          RequirerSource "_build/native-tests/module-requirer.shen"
+          Declaration "_build/native-tests/module-decl.shenmod"
+          DefaultDeclaration "_build/native-tests/module-default.shenmod"
+          TypedDeclaration "_build/native-tests/module-typed.shenmod"
+          RuntimeOnlyDeclaration "_build/native-tests/module-runtime-only.shenmod"
+          DeclaredDeclaration "_build/native-tests/module-declared.shenmod"
+          RuntimeOnlyDeclaredDeclaration "_build/native-tests/module-runtime-only-declared.shenmod"
+          MacroDeclaration "_build/native-tests/module-macro.shenmod"
+          SynonymDeclaration "_build/native-tests/module-synonym.shenmod"
+          DatatypeDeclaration "_build/native-tests/module-datatype.shenmod"
+          SourceKlDeclaration "_build/native-tests/module-source-kl.shenmod"
+          NoSourceKlDeclaration "_build/native-tests/module-no-source-kl.shenmod"
+          RequiredDeclaration "_build/native-tests/native.test.required.shenmod"
+          RequirerDeclaration "_build/native-tests/native.test.requirer.shenmod"
+          CycleADeclaration "_build/native-tests/native.test.cycle-a.shenmod"
+          CycleBDeclaration "_build/native-tests/native.test.cycle-b.shenmod"
+          BadDeclaration "_build/native-tests/module-bad.shenmod"
+          Object "_build/native-tests/module-decl.so"
+          DefaultObject "_build/native-tests/module-default.so"
+          TypedObject "_build/native-tests/module-typed.so"
+          RuntimeOnlyObject "_build/native-tests/module-runtime-only.so"
+          RequiredObject "_build/native-tests/native.test.required.so"
+          RequirerObject "_build/native-tests/native.test.requirer.so"
+          RequirerEmitObject "_build/native-tests/native.test.requirer.emit.so"
+          RequirerScheme "_build/native-tests/native.test.requirer.emit.scm"
+          Assert (/. Label Expected Actual
+                    (native-test.assert-equal Label Expected Actual))
+       (do
+         (native-test.write-file Lib (native-test.module-lib-source))
+         (native-test.write-file Main (native-test.module-main-source))
+         (native-test.write-file DefaultSource (native-test.module-default-source))
+         (native-test.write-file TypedSource (native-test.module-typed-source))
+         (native-test.write-file RuntimeOnlySource (native-test.module-runtime-only-source))
+         (native-test.write-file DeclaredSource (native-test.module-declared-source))
+         (native-test.write-file RuntimeOnlyDeclaredSource
+                                 (native-test.module-runtime-only-declared-source))
+         (native-test.write-file MacroSource (native-test.module-macro-source))
+         (native-test.write-file MacroUserSource (native-test.module-macro-user-source))
+         (native-test.write-file SynonymSource (native-test.module-synonym-source))
+         (native-test.write-file SynonymUserSource
+                                 (native-test.module-synonym-user-source))
+         (native-test.write-file DatatypeSource (native-test.module-datatype-source))
+         (native-test.write-file DatatypeUserSource
+                                 (native-test.module-datatype-user-source))
+         (native-test.write-file SourceKlSource
+                                 (native-test.module-source-kl-source))
+         (native-test.write-file NoSourceKlSource
+                                 (native-test.module-no-source-kl-source))
+         (native-test.write-file RequiredSource
+                                 (native-test.module-required-source))
+         (native-test.write-file RequirerSource
+                                 (native-test.module-requirer-source))
+         (native-test.write-file
+          Declaration
+          (native-test.module-declaration-source Lib Main))
+         (native-test.write-file
+          DefaultDeclaration
+          (native-test.module-default-declaration-source DefaultSource))
+         (native-test.write-file
+          TypedDeclaration
+          (native-test.module-typed-declaration-source TypedSource))
+         (native-test.write-file
+          RuntimeOnlyDeclaration
+          (native-test.module-runtime-only-declaration-source RuntimeOnlySource))
+         (native-test.write-file
+          DeclaredDeclaration
+          (native-test.module-declared-declaration-source DeclaredSource))
+         (native-test.write-file
+          RuntimeOnlyDeclaredDeclaration
+          (native-test.module-runtime-only-declared-declaration-source
+           RuntimeOnlyDeclaredSource))
+         (native-test.write-file
+          MacroDeclaration
+          (native-test.module-compiletime-only-declaration-source
+           native.test.macro
+           MacroSource))
+         (native-test.write-file
+          SynonymDeclaration
+          (native-test.module-compiletime-only-declaration-source
+           native.test.synonym
+           SynonymSource))
+         (native-test.write-file
+          DatatypeDeclaration
+          (native-test.module-compiletime-only-declaration-source
+           native.test.datatype
+           DatatypeSource))
+         (native-test.write-file
+          SourceKlDeclaration
+          (native-test.module-source-kl-declaration-source SourceKlSource))
+         (native-test.write-file
+          NoSourceKlDeclaration
+          (native-test.module-no-source-kl-declaration-source NoSourceKlSource))
+         (native-test.write-file
+          RequiredDeclaration
+          (native-test.module-required-declaration-source RequiredSource))
+         (native-test.write-file
+          RequirerDeclaration
+          (native-test.module-requirer-declaration-source RequirerSource))
+         (native-test.write-file
+          CycleADeclaration
+          (native-test.module-cycle-a-declaration-source DefaultSource))
+         (native-test.write-file
+          CycleBDeclaration
+          (native-test.module-cycle-b-declaration-source DefaultSource))
+         (native-test.write-file
+          BadDeclaration
+          (native-test.module-bad-declaration-source DefaultSource))
+         (let Module (shen-scheme.native-read-module-declaration Declaration)
+              Defaults (shen-scheme.native-read-module-declaration DefaultDeclaration)
+           (do
+             (Assert "module declaration name"
+                     native.test.module
+                     (shen-scheme.native-module-declaration-name Module))
+             (Assert "module declaration mode"
+                     sealed
+                     (shen-scheme.native-module-declaration-mode Module))
+             (Assert "module declaration profile"
+                     debug
+                     (shen-scheme.native-module-declaration-profile Module))
+             (Assert "module declaration sources"
+                     [Lib Main]
+                     (shen-scheme.native-module-declaration-sources Module))
+             (Assert "module declaration exports"
+                     [native-module-main]
+                     (shen-scheme.native-module-declaration-exports Module))
+             (Assert "module declaration default mode"
+                     compatible
+                     (shen-scheme.native-module-declaration-mode Defaults))
+             (Assert "module declaration default exports"
+                     infer-all
+                     (shen-scheme.native-module-declaration-exports Defaults))
+             (Assert "module declaration default profile"
+                     release
+                     (shen-scheme.native-module-declaration-profile Defaults))
+             (Assert "module declaration rejects unknown field"
+                     failed
+                     (trap-error
+                      (shen-scheme.native-read-module-declaration BadDeclaration)
+                      (/. E failed)))
+             (Assert "module metadata accepts arbitrary effects"
+                     []
+                     (shen-scheme.native-raw-compiletime-forms
+                      [[set *native-test-effect* true]]))
+             (shen-scheme.compile-module Declaration Object)
+             (shen-scheme.load-compiled Object)
+             (Assert "module declaration exported call"
+                     42
+                     (eval [native-module-main 5]))
+             (Assert "module declaration private helper hidden"
+                     unavailable
+                     (trap-error (eval [native-module-helper 5])
+                                 (/. E unavailable)))
+             (shen-scheme.compile-module DefaultDeclaration DefaultObject)
+             (shen-scheme.load-compiled DefaultObject)
+             (Assert "module declaration default compile"
+                     6
+                     (eval [native-module-default-main 5]))
+             (shen-scheme.compile-module TypedDeclaration TypedObject)
+             (shen-scheme.load-compiled TypedObject)
+             (Assert "module declaration typed call"
+                     42
+                     (eval [native-module-typed 41]))
+             (Assert "module declaration compiletime type metadata"
+                     true
+                     (not (= [] (assoc native-module-typed
+                                       (value shen.*sigf*)))))
+             (shen-scheme.compile-module RuntimeOnlyDeclaration RuntimeOnlyObject)
+             (shen-scheme.load-compiled RuntimeOnlyObject)
+             (Assert "module declaration runtime-only typed call"
+                     42
+                     (eval [native-module-runtime-only 41]))
+             (Assert "module declaration runtime-only omits compiletime metadata"
+                     []
+                     (assoc native-module-runtime-only
+                            (value shen.*sigf*)))
+             (shen-scheme.compile-module RequiredDeclaration RequiredObject)
+             (Assert "module requires needs module dir"
+                     failed
+                     (trap-error
+                      (shen-scheme.compile-module
+                       RequirerDeclaration
+                       RequirerObject)
+                      (/. E failed)))
+             (shen-scheme.compile-module/in-dir
+              RequirerDeclaration
+              RequirerObject
+              "_build/native-tests")
+             (shen-scheme.load-module
+              RequirerDeclaration
+              "_build/native-tests")
+             (Assert "module requires loaded dependency"
+                     52
+                     (eval [native-module-requirer 42]))
+             (shen-scheme.compile-module/emit/in-dir
+              RequirerDeclaration
+              RequirerEmitObject
+              RequirerScheme
+              "_build/native-tests")
+             (shen-scheme.load-compiled RequirerEmitObject)
+             (Assert "module requires emit compile"
+                     53
+                     (eval [native-module-requirer 43]))
+             (Assert "module dependency cycle detected"
+                     failed
+                     (trap-error
+                      (shen-scheme.load-module
+                       CycleADeclaration
+                       "_build/native-tests")
+                      (/. E failed))))))))
+
+(define native-test.run-app-builder
+  -> (let Result (shen-scheme.build-app/profile
+                   "tests/native/app-main.shen"
+                   ["tests/native/app-lib.shen"]
+                   "_build/native-tests/app-wpo.so"
+                   wpo)
+          Object (hd Result)
+          RuntimeLibraries (hd (tl Result))
+          Assert (/. Label Expected Actual
+                    (native-test.assert-equal Label Expected Actual))
+       (do
+         (Assert "app builder object" "_build/native-tests/app-wpo.so" Object)
+         (Assert "app builder WPO runtime libraries"
+                 [[shen-scheme runtime]]
+                 RuntimeLibraries)
+         (shen-scheme.load-compiled Object)
+         (Assert "app builder initializer order"
+                 [1 12]
+                 (value *native-app-init-events*))
+         (Assert "app builder cross-module call" 52 (eval [native-app-main 41]))
+         (Assert "app builder direct module call" 42 (eval [native-app-direct 41]))
+         (Assert "app builder runtime global call" 3 (eval [native-app-length [cons 1 [cons 2 [cons 3 []]]]]))
+         (Assert "app builder absvector fallback" true (eval [native-app-absvector?]))
+         (Assert "app builder generic equality fallback" true (eval [native-app-list-equal?]))
+         (Assert "app builder static global fallback" true (eval [native-app-sysfunc?])))))
+
+(define native-test.run-module-app-builder
+  -> (let BaseSource "_build/native-tests/module-app-base.shen"
+          BaseUpdatedSource "_build/native-tests/module-app-base-updated.shen"
+          MainSource "_build/native-tests/module-app-main.shen"
+          PrivateCallSource "_build/native-tests/module-app-private-call.shen"
+          BaseDeclaration "_build/native-tests/native.test.app-base.shenmod"
+          MainDeclaration "_build/native-tests/native.test.app-main.shenmod"
+          PrivateCallDeclaration "_build/native-tests/native.test.app-private-call.shenmod"
+          MissingRequireDeclaration "_build/native-tests/native.test.app-missing-require.shenmod"
+          BadExportDeclaration "_build/native-tests/native.test.app-bad-export.shenmod"
+          Object "_build/native-tests/module-app-wpo.so"
+          Assert (/. Label Expected Actual
+                    (native-test.assert-equal Label Expected Actual))
+       (do
+         (native-test.write-file BaseSource
+                                 (native-test.module-app-base-source))
+         (native-test.write-file BaseUpdatedSource
+                                 (native-test.module-app-base-updated-source))
+         (native-test.write-file MainSource
+                                 (native-test.module-app-main-source))
+         (native-test.write-file
+          PrivateCallSource
+          (native-test.module-app-private-call-source))
+         (native-test.write-file
+          BaseDeclaration
+          (native-test.module-app-base-declaration-source BaseSource))
+         (native-test.write-file
+          MainDeclaration
+          (native-test.module-app-main-declaration-source MainSource))
+         (native-test.write-file
+          PrivateCallDeclaration
+          (native-test.module-app-private-call-declaration-source
+           PrivateCallSource))
+         (native-test.write-file
+          MissingRequireDeclaration
+          (native-test.module-app-missing-require-declaration-source MainSource))
+         (native-test.write-file
+          BadExportDeclaration
+          (native-test.module-app-bad-export-declaration-source MainSource))
+         (let Result (shen-scheme.build-module-app/wpo
+                      MainDeclaration
+                      "_build/native-tests"
+                      Object)
+              BuiltObject (hd Result)
+              RuntimeLibraries (hd (tl Result))
+          (do
+            (Assert "module app builder object" Object BuiltObject)
+            (Assert "module app builder WPO runtime libraries"
+                    [[shen-scheme runtime]]
+                    RuntimeLibraries)
+            (shen-scheme.load-compiled Object)
+            (Assert "module app initializer order"
+                    [10 11]
+                    (value *native-module-app-init-events*))
+            (Assert "module app cross-module direct call"
+                    42
+                    (eval [native-module-app-main 32]))
+            (Assert "module app private dependency hidden"
+                    unavailable
+                    (trap-error (eval [native-module-app-private 1])
+                                (/. E unavailable)))
+            (load BaseUpdatedSource)
+            (Assert "module app dependency redefined"
+                    1001
+                    (eval [native-module-app-base 1]))
+            (Assert "module app keeps imported dependency binding"
+                    42
+                    (eval [native-module-app-main 32]))
+            (Assert "module app missing dependency declaration fails"
+                    failed
+                    (trap-error
+                     (shen-scheme.build-module-app/wpo
+                      MissingRequireDeclaration
+                      "_build/native-tests"
+                      "_build/native-tests/module-app-missing-require.so")
+                     (/. E failed)))
+            (Assert "module app unknown export fails"
+                    failed
+                    (trap-error
+                     (shen-scheme.build-module-app/wpo
+                      BadExportDeclaration
+                      "_build/native-tests"
+                      "_build/native-tests/module-app-bad-export.so")
+                     (/. E failed)))
+            (let PrivateResult
+                 (shen-scheme.build-module-app/wpo
+                  PrivateCallDeclaration
+                  "_build/native-tests"
+                  "_build/native-tests/module-app-private-call.so")
+              (do
+                (shen-scheme.load-compiled (hd PrivateResult))
+                (Assert "module app private dependency stays unavailable"
+                        unavailable
+                        (trap-error
+                         (eval [native-module-app-private-probe 1])
+                         (/. E unavailable))))))))))
+
+(define native-test.run
+  -> (do
+    (native-test.run-refactor-regressions)
+    (native-test.compile-load
+      "tests/native/simple.shen"
+      "_build/native-tests/api-simple.so"
+      "_build/native-tests/api-simple.scm")
+    (native-test.assert-simple "api first load" 42 8 15 [2 3 4])
+    (native-test.compile-load
+      "tests/native/simple-updated.shen"
+      "_build/native-tests/api-simple-updated.so"
+      "_build/native-tests/api-simple-updated.scm")
+    (native-test.assert-simple "api reload" 52 18 115 [12 13 14])
+    (native-test.run-direct-compile)
+    (native-test.run-prolog)
+    (native-test.run-package-effects)
+    (native-test.run-profiles)
+    (native-test.run-module-declarations)
+    (native-test.run-private-dependency-arity)
+    (native-test.run-dependency-package-metadata)
+    (native-test.run-compatible-redefinition)
+    (native-test.run-sealed-redefinition)
+    (native-test.run-app-builder)
+    (native-test.run-module-app-builder)
+    (native-test.run-core-regressions)
+    (native-test.run-module-dependency-regressions)))
+
+(load "scripts/run-native-core-regression-tests.shen")
+(load "scripts/run-native-module-regression-tests.shen")
+(native-test.run)

--- a/src/compiler.shen
+++ b/src/compiler.shen
@@ -8,6 +8,8 @@
                      eq? eqv? equal? scm. scm.import import *sterror* *toplevel*
                      letrec let* scm.letrec scm.with-input-from-string scm.read
                      scm.define scm.goto-label scm.begin
+                     compatible sealed app
+                     scm.dynamic-wind
                      scm.value/or scm.get/or scm.<-vector/or scm.<-address/or]
 
 (define initialize-compiler
@@ -35,7 +37,9 @@
            \\_scm.*static-globals*
            \\_scm.*compiling-shen-sources*
          ])
-         (set *global-prefix* (intern "kl:global/"))))
+         (set *global-prefix* (intern "kl:global/"))
+         (set *native-mode* compatible)
+         (set *native-local-map* [])))
 
 (define unbound-symbol?
   Sym Scope -> (not (element? Sym Scope)) where (or (symbol? Sym) (= Sym ,))
@@ -98,7 +102,11 @@
   [tlstr S] Scope -> [let [[tmp (compile-expression S Scope)]]
                        [substring tmp 1 [string-length tmp]]]
   [absvector N] Scope -> [make-vector (compile-expression N Scope)
-                                      [(prefix-op fail)]]
+                                      (emit-static-application-fallback
+                                       (native-mode)
+                                       fail
+                                       []
+                                       Scope)]
   [<-address V N] Scope -> [vector-ref (compile-expression V Scope)
                                        (compile-expression N Scope)]
   [address-> V N X] Scope -> [let [[tmp (compile-expression V Scope)]]
@@ -114,6 +122,8 @@
   [scm. Code] _ -> ((foreign scm.with-input-from-string) Code (freeze ((foreign scm.read)))) where (string? Code)
   [scm. Form] _ -> (emit-scm-form Form)
   [scm. kl : Name] _ -> (intern (cn "kl:" (str Name))) where (symbol? Name)
+  [fn Name] _ -> (native-local-name Name)
+      where (not (= (native-local-name Name) (fail)))
   [Op | Args] Scope -> (emit-application Op Args Scope)
   X _ -> X                      \* literal *\
   )
@@ -240,9 +250,11 @@ but not otherwise.
       where (or (string? V1) (string? V2))
   [] V2 Scope -> [null? (compile-expression V2 Scope)]
   V1 [] Scope -> [null? (compile-expression V1 Scope)]
-  V1 V2 Scope -> [(intern "kl:=")
-                  (compile-expression V1 Scope)
-                  (compile-expression V2 Scope)])
+  V1 V2 Scope -> (emit-static-application-fallback
+                  (native-mode)
+                  =
+                  [V1 V2]
+                  Scope))
 
 (define binary-op-mapping
   +               -> +
@@ -265,6 +277,10 @@ but not otherwise.
   hd              -> car
   tl              -> cdr
   _               -> (fail))
+
+(define emit-static-application-fallback
+  _ Op Params Scope -> (let Args (map (/. P (compile-expression P Scope)) Params)
+                         [(prefix-op Op) | Args]))
 
 (define emit-application
   Op Params Scope -> (emit-application* Op (arity Op) Params Scope))
@@ -300,6 +316,42 @@ but not otherwise.
 (define prefix-global
   Sym -> (concat (value *global-prefix*) Sym))
 
+(define native-mode
+  -> (trap-error (value *native-mode*) (/. E compatible)))
+
+(define native-local-map
+  -> (trap-error (value *native-local-map*) (/. E [])))
+
+(define with-native-context
+  Mode LocalMap F -> (let OldMode (native-mode)
+                          OldLocalMap (native-local-map)
+                       ((foreign scm.dynamic-wind)
+                        (freeze
+                         (do (set *native-mode* Mode)
+                             (set *native-local-map* LocalMap)))
+                        F
+                        (freeze
+                         (do (set *native-mode* OldMode)
+                             (set *native-local-map* OldLocalMap))))))
+
+(define native-local-name*
+  _ [] -> (fail)
+  Op [[Op Local] | _] -> Local
+  Op [_ | Rest] -> (native-local-name* Op Rest))
+
+(define native-local-name-for-mode
+  sealed Op -> (native-local-name* Op (native-local-map))
+  app Op -> (native-local-name* Op (native-local-map))
+  _ _ -> (fail))
+
+(define native-local-name
+  Op -> (native-local-name-for-mode (native-mode) Op))
+
+(define definition-name
+  Name -> (native-local-name Name)
+      where (not (= (native-local-name Name) (fail)))
+  Name -> (prefix-op Name))
+
 (define not-fail
   Obj F -> (F Obj) where (not (= Obj (fail)))
   Obj _ -> Obj)
@@ -323,9 +375,17 @@ but not otherwise.
                             (let Args (map (/. P (compile-expression P Scope))
                                            Params)
                               [MappedOp | Args])))
-  Op _ Params Scope -> (let Args (map (/. P (compile-expression P Scope))
-                                      Params)
-                         [(prefix-op Op) | Args]))
+  Op _ Params Scope <- (not-fail
+                        (native-local-name Op)
+                        (/. LocalOp
+                            (let Args (map (/. P (compile-expression P Scope))
+                                           Params)
+                              [LocalOp | Args])))
+  Op _ Params Scope -> (emit-static-application-fallback
+                        (native-mode)
+                        Op
+                        Params
+                        Scope))
 
 (define emit-application*
   Op Arity Params Scope
@@ -349,14 +409,14 @@ but not otherwise.
 
 (define compile-factorised-branches
   [] -> []
-  [[defun Name Args Body] | Rest] -> [[define [(prefix-op Name) | Args] (compile-expression Body Args)]
+  [[defun Name Args Body] | Rest] -> [[define [(definition-name Name) | Args] (compile-expression Body Args)]
                                       | (compile-factorised-branches Rest)])
 
 (define kl->scheme
   [defun Name Args Body] -> (let Branches (trap-error (value shen.*branches-stack*) (/. E []))
                                  Clear (set shen.*branches-stack* [])
                               (compiling-function Name
-                                (freeze [define [(prefix-op Name) | Args] |
+                                (freeze [define [(definition-name Name) | Args] |
                                           (append
                                             (compile-factorised-branches Branches)
                                             [(compile-expression Body Args)])])))

--- a/src/native-app.shen
+++ b/src/native-app.shen
@@ -1,0 +1,232 @@
+\* Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(package shen-scheme
+ [app native-unit module-declaration module-app-map runtime infer-all
+  defun define quote module loaded
+  scm.shen-scheme-native-key]
+
+(define native-app-sources
+  M Ms -> (append Ms [M]))
+
+(define native-app-key
+  Ss Os WPO? -> ((foreign scm.shen-scheme-native-key) Ss [Os WPO?]))
+
+(define native-app-name-string
+  K -> (make-string "app_~A" K))
+
+(define native-app-root
+  Dir K -> (make-string "~A/~A" Dir K))
+
+(define native-app-module-local-symbol
+  MI FI -> (intern (make-string "shen_native_m~A_f~A" MI FI)))
+
+(define native-app-local-map
+  KL MI -> (native-app-local-map* KL MI 0))
+
+(define native-app-local-map*
+  [] _ _ -> []
+  [[defun F _ _] | KL] MI FI
+  -> [[F (native-app-module-local-symbol MI FI)] |
+      (native-app-local-map* KL MI (+ FI 1))])
+
+(define native-app-flatten-local-maps
+  [] -> []
+  [M | Ms] -> (append M (native-app-flatten-local-maps Ms)))
+
+(define native-app-module-name
+  App MI -> (intern (make-string "shen_native_~A_module~A" App MI)))
+
+(define native-app-runtime-installer
+  MI -> (intern (make-string "install-runtime-~A!" MI)))
+
+(define native-app-compiletime-installer
+  MI -> (intern (make-string "install-compiletime-~A!" MI)))
+
+(define native-app-init-installer
+  MI -> (intern (make-string "install-init-~A!" MI)))
+
+(define native-app-exports
+  LM RI CI II -> (append (map (function native-mapping-local) LM) [RI CI II]))
+
+(define native-app-module-form
+  App MI [native-unit KL Is _ Ps] LM PMs
+  -> (let M (native-app-module-name App MI)
+          RI (native-app-runtime-installer MI)
+          CI (native-app-compiletime-installer MI)
+          II (native-app-init-installer MI)
+          VM (append LM (native-app-flatten-local-maps PMs))
+          Ds (native-compile-kl-forms app VM KL)
+          Init (native-compile-kl-forms app VM Is)
+          RT (native-module-runtime-forms KL LM infer-all [runtime] Ps)
+          Run (native-module-init-forms Init)
+       [module M (native-app-exports LM RI CI II)
+        | (append Ds [[define [RI] | RT]
+                      [define [CI] [quote loaded]]
+                      [define [II] | Run]])]))
+
+(define native-app-module-forms*
+  [] _ _ _ -> []
+  [S | Ss] App MI Ms
+  -> (let U (native-source->unit S)
+          KL (native-unit-kl U)
+          LM (native-app-local-map KL MI)
+       [(native-app-module-form App MI U LM Ms) |
+        (native-app-module-forms* Ss App (+ MI 1) [LM | Ms])]))
+
+(define native-app-module-forms
+  Ss App -> (with-native-compiler-state
+             (freeze (native-app-module-forms* Ss App 0 []))))
+
+(define native-app-install-forms*
+  N N -> []
+  I N -> [[(native-app-runtime-installer I)]
+          [(native-app-compiletime-installer I)]
+          [(native-app-init-installer I)]
+          | (native-app-install-forms* (+ I 1) N)])
+
+(define native-app-install-forms
+  N -> (native-app-install-forms* 0 N))
+
+(define native-module-app-result-loaded
+  [L _] -> L)
+
+(define native-module-app-result-declarations
+  [_ Ds] -> Ds)
+
+(define native-module-app-declarations
+  D Dir -> (reverse (native-module-app-result-declarations
+                     (native-module-app-declarations* D Dir [] [] []))))
+
+(define native-module-app-declarations*
+  D Dir Stack L Ds
+  -> (let M (native-module-declaration-name D)
+       (if (element? M Stack)
+           (native-cycle-error M)
+           (if (element? M L)
+               [L Ds]
+               (let R (native-module-app-requirements
+                        (native-module-declaration-requires D)
+                        Dir [M | Stack] L Ds)
+                    L (native-module-app-result-loaded R)
+                    Ds (native-module-app-result-declarations R)
+                 [[M | L] [D | Ds]])))))
+
+(define native-module-app-requirements
+  [] _ _ L Ds -> [L Ds]
+  [M | Ms] Dir Stack L Ds
+  -> (let P (native-module-declaration-path Dir M)
+          P (native-require-existing-file P "required module declaration")
+          D (native-read-module-declaration P)
+          R (native-module-app-declarations* D Dir Stack L Ds)
+       (native-module-app-requirements
+        Ms Dir Stack
+        (native-module-app-result-loaded R)
+        (native-module-app-result-declarations R))))
+
+(define native-module-app-sources
+  [] -> []
+  [[module-declaration _ _ Ss _ _ _ _] | Ds]
+  -> (append Ss (native-module-app-sources Ds)))
+
+(define native-module-app-key
+  Ds Os WPO? -> ((foreign scm.shen-scheme-native-key)
+                 (native-module-app-sources Ds)
+                 [(map (function native-module-declaration-key) Ds) Os WPO?]))
+
+(define native-module-app-map-exports
+  [module-app-map _ _ Xs _] -> Xs)
+
+(define native-module-app-map-arities
+  [module-app-map _ _ _ As] -> As)
+
+(define native-module-app-find-map
+  M [] -> (error "native module app missing required module: ~A~%" M)
+  M [[module-app-map N I Xs As] | Ms]
+  -> (if (= M N)
+         [module-app-map N I Xs As]
+         (native-module-app-find-map M Ms)))
+
+(define native-module-app-required-visible-map
+  [] _ -> []
+  [R | Rs] Ms
+  -> (append (native-module-app-required-visible-map Rs Ms)
+             (native-module-app-map-exports (native-module-app-find-map R Ms))))
+
+(define native-module-app-required-visible-arities
+  [] _ -> []
+  [R | Rs] Ms
+  -> (append
+      (native-module-app-required-visible-arities Rs Ms)
+      (native-module-app-map-arities (native-module-app-find-map R Ms))))
+
+(define native-module-app-export-owner
+  _ [] -> []
+  F [[F R] | _] -> [R]
+  F [_ | Xs] -> (native-module-app-export-owner F Xs))
+
+(define native-module-app-record-exports
+  _ [] Seen -> Seen
+  R [[F _] | Xs] Seen
+  -> (let Owner (native-module-app-export-owner F Seen)
+       (if (= [] Owner)
+           (native-module-app-record-exports R Xs [[F R] | Seen])
+           (error "native module app has ambiguous exported function ~A in direct requirements ~A and ~A~%"
+                  F (hd Owner) R))))
+
+(define native-module-app-validate-required-exports
+  Rs Ms -> (native-module-app-validate-required-exports* Rs Ms []))
+
+(define native-module-app-validate-required-exports*
+  [] _ _ -> skip
+  [R | Rs] Ms Seen
+  -> (let Xs (native-module-app-map-exports
+              (native-module-app-find-map R Ms))
+          Seen (native-module-app-record-exports R Xs Seen)
+       (native-module-app-validate-required-exports* Rs Ms Seen)))
+
+(define native-module-app-module-form
+  App I Xs MD [native-unit KL Is CT Ps] LM XM RM
+  -> (let M (native-app-module-name App I)
+          RI (native-app-runtime-installer I)
+          CI (native-app-compiletime-installer I)
+          II (native-app-init-installer I)
+          VM (append LM RM)
+          Ds (native-compile-kl-forms app VM KL)
+          Init (native-compile-kl-forms app VM Is)
+          RT (native-module-runtime-forms KL LM Xs MD Ps)
+          Meta (native-module-compiletime-forms KL CT MD)
+          Run (native-module-init-forms Init)
+       [module M (native-app-exports XM RI CI II)
+        | (append Ds [[define [RI] | RT]
+                      [define [CI] | Meta]
+                      [define [II] | Run]])]))
+
+(define native-module-app-module-forms-result-forms
+  [_ Fs] -> Fs)
+
+(define native-module-app-module-forms
+  Ds App -> (with-native-compiler-state
+             (freeze
+              (reverse (native-module-app-module-forms-result-forms
+                        (native-module-app-module-forms*
+                         Ds App 0 [] []))))))
+
+(define native-module-app-module-forms*
+  [] _ _ Ms Fs -> [Ms Fs]
+  [[module-declaration N _ Ss Rs Xs MD _] | Ds] App I Ms Fs
+  -> (do (native-module-app-validate-required-exports Rs Ms)
+         (let RM (native-module-app-required-visible-map Rs Ms)
+              As (native-module-app-required-visible-arities Rs Ms)
+              U (native-sources->unit/with-arities Ss As)
+              KL (native-unit-kl U)
+              LM (native-app-local-map KL I)
+              CXs (native-validate-exports Xs LM)
+              XM (native-exported-local-map LM CXs)
+              AM (native-exported-arities KL CXs)
+              F (native-module-app-module-form App I CXs MD U LM XM RM)
+              MM [module-app-map N I XM AM]
+           (native-module-app-module-forms*
+            Ds App (+ I 1) [MM | Ms] [F | Fs]))))
+
+)

--- a/src/native-codegen.shen
+++ b/src/native-codegen.shen
@@ -1,0 +1,161 @@
+\* Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(package shen-scheme
+ [compatible sealed infer-all runtime compiletime source-kl
+  native-unit defun define quote module import if begin define-top-level-value skip
+  update-lambda-table install-runtime! install-compiletime! install-init! loaded
+  shen-scheme-native-load-init?
+  _scm.prefix-op _scm.kl->scheme _scm.with-native-context
+  scm.shen-scheme-native-key]
+
+(define native-scheme-forms
+  S -> (native-scheme-forms/mode S compatible))
+
+(define native-scheme-forms/mode
+  S M -> (let M (native-compile-mode M)
+           (native-scheme-forms* (native-module-name/mode S M)
+                                 (native-source->unit S)
+                                 M infer-all [runtime compiletime])))
+
+(define native-scheme-forms*
+  _ U compatible infer-all MD -> (native-compatible-scheme-forms U MD)
+  _ _ compatible Xs _ -> (error "native compiler explicit exports require sealed mode, got: ~S~%" Xs)
+  M U sealed Xs MD -> (native-sealed-scheme-forms* M U Xs MD))
+
+(define native-compile-kl-forms
+  M LM KL -> (_scm.with-native-context
+              M LM (freeze (map (function _scm.kl->scheme) KL))))
+
+(define native-compatible-scheme-forms
+  [native-unit KL Is CT Ps] MD
+  -> (let Ds (native-compile-kl-forms compatible [] KL)
+          RT (native-runtime-metadata-forms KL MD)
+          Meta (native-compiletime-metadata-forms KL CT MD)
+          Init (native-compile-kl-forms compatible [] Is)
+       (append Ds RT Ps Meta
+               [(native-load-init-form (append Init [[quote loaded]]))])))
+
+(define native-compile-mode
+  compatible -> compatible
+  sealed -> sealed
+  "compatible" -> compatible
+  "sealed" -> sealed
+  M -> (error "native compiler expected mode compatible or sealed, got: ~S~%" M))
+
+(define native-local-map
+  KL -> (native-local-map* KL 0))
+
+(define native-local-map*
+  [] _ -> []
+  [[defun F _ _] | KL] N -> [[F (native-local-symbol N)] |
+                             (native-local-map* KL (+ N 1))])
+
+(define native-local-symbol
+  N -> (intern (@s "shen_native_" (str N))))
+
+(define native-module-name
+  S -> (intern (@s "shen_native_unit_"
+                  ((foreign scm.shen-scheme-native-key) [S] [sealed]))))
+
+(define native-module-name/mode
+  _ compatible -> skip
+  S sealed -> (native-module-name S))
+
+(define native-export-form
+  [F L] -> [define-top-level-value [quote (_scm.prefix-op F)] L])
+
+(define native-export-forms
+  Ms -> (map (function native-export-form) Ms))
+
+(define native-mapping-name
+  [F _] -> F)
+
+(define native-mapping-local
+  [_ L] -> L)
+
+(define native-runtime-metadata-forms
+  KL MD -> (if (element? runtime MD) (map (function native-arity-form) KL) []))
+
+(define native-source-kl-form
+  [defun F As B] -> [(_scm.prefix-op shen.record-kl) [quote F]
+                     [quote [defun F As B]]])
+
+(define native-source-kl-forms
+  KL MD -> (if (element? source-kl MD)
+               (map (function native-source-kl-form) KL)
+               []))
+
+(define native-compiletime-metadata-forms
+  KL CT MD
+  -> (append (if (element? compiletime MD)
+                     CT
+                     [])
+                  (native-source-kl-forms KL MD)))
+
+(define native-exported-local-map
+  LM infer-all -> LM
+  [] _ -> []
+  [[F L] | Ms] Xs -> (if (element? F Xs)
+                         [[F L] | (native-exported-local-map Ms Xs)]
+                         (native-exported-local-map Ms Xs)))
+
+(define native-exported-kl
+  KL infer-all -> KL
+  [] _ -> []
+  [[defun F As B] | KL] Xs -> (if (element? F Xs)
+                                  [[defun F As B] | (native-exported-kl KL Xs)]
+                                  (native-exported-kl KL Xs)))
+
+(define native-validate-exports
+  infer-all _ -> infer-all
+  [] _ -> []
+  [X | Xs] LM -> [X | (native-validate-exports Xs LM)]
+    where (element? X (map (function native-mapping-name) LM))
+  [X | _] _ -> (error "native module declaration exports unknown function: ~S~%" X))
+
+(define native-module-runtime-forms
+  KL LM Xs MD Ps
+  -> (append (if (element? runtime MD)
+                 (append (native-export-forms
+                          (native-exported-local-map LM Xs))
+                         (map (function native-arity-form)
+                              (native-exported-kl KL Xs)))
+                 [])
+             Ps [[quote loaded]]))
+
+(define native-module-compiletime-forms
+  KL CT MD
+  -> (append (native-compiletime-metadata-forms KL CT MD) [[quote loaded]]))
+
+(define native-module-init-forms
+  Is -> (append Is [[quote loaded]]))
+
+(define native-load-init-form
+  Is -> [if [shen-scheme-native-load-init?] [begin | Is] [quote loaded]])
+
+(define native-sealed-module-form
+  M Ds RT CT Is
+  -> [module M [install-runtime! install-compiletime! install-init!]
+                 | (append Ds [[define [install-runtime!] | RT]
+                               [define [install-compiletime!] | CT]
+                               [define [install-init!] | Is]])])
+
+(define native-sealed-scheme-forms
+  S -> (native-sealed-scheme-forms* (native-module-name S) (native-source->unit S)
+                                    infer-all [runtime compiletime]))
+
+(define native-sealed-scheme-forms*
+  M [native-unit KL Is CT Ps] Xs MD
+  -> (let LM (native-local-map KL)
+          CXs (native-validate-exports Xs LM)
+          Ds (native-compile-kl-forms sealed LM KL)
+          Init (native-compile-kl-forms sealed LM Is)
+          RT (native-module-runtime-forms KL LM CXs MD Ps)
+          Meta (native-module-compiletime-forms KL CT MD)
+          Run (native-module-init-forms Init)
+       [(native-sealed-module-form M Ds RT Meta Run)
+        [import M] [install-runtime!] [install-compiletime!]
+        (native-load-init-form [[install-init!]])]))
+
+)

--- a/src/native-compiler.shen
+++ b/src/native-compiler.shen
@@ -1,0 +1,161 @@
+\* Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(package shen-scheme
+ [compatible
+  scm.shen-scheme-compile-native-app
+  scm.shen-scheme-compile-native-forms-direct
+  scm.shen-scheme-compile-native-forms
+  scm.shen-scheme-delete-file-if-exists
+  scm.file-exists?]
+
+(define native-compile-forms/direct
+  O Fs [Opt Debug Inspect Src WPO?]
+  -> ((foreign scm.shen-scheme-compile-native-forms-direct) O Fs Opt Debug Inspect Src WPO?))
+
+(define native-compile-forms/emit
+  Scm O Fs [Opt Debug Inspect Src WPO?]
+  -> ((foreign scm.shen-scheme-compile-native-forms) Scm O Fs Opt Debug Inspect Src WPO?))
+
+(define native-compile-app
+  Root Ms Fs O [Opt Debug Inspect Src _] WPO?
+  -> ((foreign scm.shen-scheme-compile-native-app) Root Ms Fs O Opt Debug Inspect Src WPO?))
+
+(define build-app
+  M Ms O -> (build-app/emit/options M Ms O "_build/native-app" (native-compile-options) false))
+
+(define build-app/wpo
+  M Ms O -> (build-app/emit/options M Ms O "_build/native-app" (native-compile-options) true))
+
+(define build-app/profile
+  M Ms O P -> (build-app/emit/options M Ms O "_build/native-app" (native-compile-profile-options P) false))
+
+(define build-app/wpo/profile
+  M Ms O P -> (build-app/emit/options M Ms O "_build/native-app" (native-compile-profile-options P) true))
+
+(define build-app/emit/options
+  M Ms O Dir Os WPO?
+  -> (let Ss (native-app-sources M Ms)
+          WPO? (native-effective-wpo? Os WPO?)
+          K (native-app-key Ss [O | Os] WPO?)
+          AppS (native-app-name-string K)
+          App (intern AppS)
+          Root (native-app-root Dir K)
+          MF (native-app-module-forms Ss App)
+          PF (native-app-install-forms (length Ss))
+       (native-compile-app Root MF PF O Os WPO?)))
+
+(define build-module-app
+  F Dir O -> (build-module-app/emit/options F Dir O "_build/native-module-app" (native-compile-options) false))
+
+(define build-module-app/wpo
+  F Dir O -> (build-module-app/emit/options F Dir O "_build/native-module-app" (native-compile-options) true))
+
+(define build-module-app/profile
+  F Dir O P -> (build-module-app/emit/options F Dir O "_build/native-module-app" (native-compile-profile-options P) false))
+
+(define build-module-app/wpo/profile
+  F Dir O P -> (build-module-app/emit/options F Dir O "_build/native-module-app" (native-compile-profile-options P) true))
+
+(define build-module-app/emit/options
+  F Dir O Base Os WPO?
+  -> (let D (native-read-module-declaration F)
+          Ds (native-module-app-declarations D Dir)
+          WPO? (native-effective-wpo? Os WPO?)
+          K (native-module-app-key Ds [O | Os] WPO?)
+          AppS (native-app-name-string K)
+          App (intern AppS)
+          Root (native-app-root Base K)
+          MF (native-module-app-module-forms Ds App)
+          PF (native-app-install-forms (length Ds))
+       (native-compile-app Root MF PF O Os WPO?)))
+
+(define compile-module
+  F O -> (compile-module/declaration (native-read-module-declaration F) O))
+
+(define compile-module/declaration
+  D O -> (do (native-require-module-dir (native-module-declaration-requires D) (fail))
+             (compile-module/declaration* D O)))
+
+(define compile-module/declaration*
+  D O -> (let Os (native-compile-profile-options (native-module-declaration-profile D))
+              Fs (native-module-declaration-scheme-forms D)
+           (native-compile-forms/direct O Fs Os)))
+
+(define compile-module/in-dir
+  F O Dir -> (compile-module/declaration/in-dir (native-read-module-declaration F) O Dir))
+
+(define compile-module/declaration/in-dir
+  D O Dir -> (with-native-compiler-state
+              (freeze
+               (do (native-prepare-module-requirements
+                    (native-module-declaration-requires D) Dir
+                    [(native-module-declaration-name D)] [])
+                   (compile-module/declaration* D O)))))
+
+(define compile-module/emit
+  F O Scm -> (compile-module/emit/declaration (native-read-module-declaration F) O Scm))
+
+(define compile-module/emit/declaration
+  D O Scm -> (do (native-require-module-dir (native-module-declaration-requires D) (fail))
+                 (compile-module/emit/declaration* D O Scm)))
+
+(define compile-module/emit/declaration*
+  D O Scm -> (let Os (native-compile-profile-options (native-module-declaration-profile D))
+                  Fs (native-module-declaration-scheme-forms D)
+               (native-compile-forms/emit Scm O Fs Os)))
+
+(define compile-module/emit/in-dir
+  F O Scm Dir -> (compile-module/emit/declaration/in-dir (native-read-module-declaration F) O Scm Dir))
+
+(define compile-module/emit/declaration/in-dir
+  D O Scm Dir -> (with-native-compiler-state
+                  (freeze
+                   (do (native-prepare-module-requirements
+                        (native-module-declaration-requires D) Dir
+                        [(native-module-declaration-name D)] [])
+                       (compile-module/emit/declaration* D O Scm)))))
+
+(define compile-file
+  S O -> (compile-file/options S O (native-compile-options)))
+
+(define compile-file/mode
+  S O M -> (compile-file/options/mode S O (native-compile-options) M))
+
+(define compile-file/profile
+  S O P -> (compile-file/options S O (native-compile-profile-options P)))
+
+(define compile-file/profile/mode
+  S O P M -> (compile-file/options/mode S O (native-compile-profile-options P) M))
+
+(define compile-file/options
+  S O Os -> (compile-file/options/mode S O Os compatible))
+
+(define compile-file/options/mode
+  S O Os M -> (native-compile-forms/direct O (native-scheme-forms/mode S M) Os))
+
+(define compile-file/emit
+  S O Scm -> (compile-file/emit/options S O Scm (native-compile-options)))
+
+(define compile-file/emit/mode
+  S O Scm M -> (compile-file/emit/options/mode S O Scm (native-compile-options) M))
+
+(define compile-file/emit/profile
+  S O Scm P -> (compile-file/emit/options S O Scm (native-compile-profile-options P)))
+
+(define compile-file/emit/profile/mode
+  S O Scm P M -> (compile-file/emit/options/mode S O Scm (native-compile-profile-options P) M))
+
+(define compile-file/emit/options
+  S O Scm Os -> (compile-file/emit/options/mode S O Scm Os compatible))
+
+(define compile-file/emit/options/mode
+  S O Scm Os M -> (native-compile-forms/emit Scm O (native-scheme-forms/mode S M) Os))
+
+(define delete-file-if-exists
+  F -> ((foreign scm.shen-scheme-delete-file-if-exists) F))
+
+(define shen-scheme.file-exists?
+  F -> ((foreign scm.file-exists?) F))
+
+)

--- a/src/native-modules.shen
+++ b/src/native-modules.shen
@@ -1,0 +1,282 @@
+\* Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(package shen-scheme
+ [shen.aot.module name mode sources requires exports metadata profile
+  module-declaration infer-all runtime compiletime source-kl
+  compatible sealed release skip
+  update-lambda-table
+  scm.shen-scheme-native-key scm.shen-scheme-load-compiled
+  scm.shen-scheme-load-compiled-for-compilation
+  scm.file-exists? scm.dynamic-wind]
+
+(define native-single-form
+  _ [F] -> F
+  P [] -> (error "native module declaration ~A is empty~%" P)
+  P Fs -> (error "native module declaration ~A expected one top-level form, got ~A~%"
+                 P (length Fs)))
+
+(define native-read-module-declaration
+  P -> (native-parse-module-declaration
+        (native-single-form P (read-file-unprocessed P))))
+
+(define native-parse-module-declaration
+  [shen.aot.module | Fs] -> (native-parse-module-fields
+                             Fs [] (fail) compatible [] [] infer-all
+                             [runtime compiletime] release)
+  F -> (error "native module declaration expected shen.aot.module form, got: ~S~%" F))
+
+(define native-add-seen-field
+  F Seen -> (if (element? F Seen)
+                (error "native module declaration has duplicate field: ~A~%" F)
+                [F | Seen]))
+
+(define native-parse-module-fields
+  [] _ N M Ss Rs Xs MD P
+  -> (native-finalize-module-declaration N M Ss Rs Xs MD P)
+  [[name N] | Fs] Seen _ M Ss Rs Xs MD P
+  -> (native-parse-module-fields Fs (native-add-seen-field name Seen)
+                                 N M Ss Rs Xs MD P)
+  [[mode M] | Fs] Seen N _ Ss Rs Xs MD P
+  -> (native-parse-module-fields Fs (native-add-seen-field mode Seen)
+                                 N M Ss Rs Xs MD P)
+  [[sources | Ss] | Fs] Seen N M _ Rs Xs MD P
+  -> (native-parse-module-fields Fs (native-add-seen-field sources Seen)
+                                 N M Ss Rs Xs MD P)
+  [[requires | Rs] | Fs] Seen N M Ss _ Xs MD P
+  -> (native-parse-module-fields Fs (native-add-seen-field requires Seen)
+                                 N M Ss Rs Xs MD P)
+  [[exports infer-all] | Fs] Seen N M Ss Rs _ MD P
+  -> (native-parse-module-fields Fs (native-add-seen-field exports Seen)
+                                 N M Ss Rs infer-all MD P)
+  [[exports | Xs] | Fs] Seen N M Ss Rs _ MD P
+  -> (native-parse-module-fields Fs (native-add-seen-field exports Seen)
+                                 N M Ss Rs Xs MD P)
+  [[metadata | MD] | Fs] Seen N M Ss Rs Xs _ P
+  -> (native-parse-module-fields Fs (native-add-seen-field metadata Seen)
+                                 N M Ss Rs Xs MD P)
+  [[profile P] | Fs] Seen N M Ss Rs Xs MD _
+  -> (native-parse-module-fields Fs (native-add-seen-field profile Seen)
+                                 N M Ss Rs Xs MD P)
+  [F | _] _ _ _ _ _ _ _ _
+  -> (error "native module declaration has unknown or malformed field: ~S~%" F))
+
+(define native-finalize-module-declaration
+  N M Ss Rs Xs MD P
+  -> (error "native module declaration requires a name field~%")
+    where (= N (fail))
+  N M Ss Rs Xs MD P
+  -> [module-declaration (native-module-symbol name N) (native-compile-mode M)
+      (native-source-list Ss) (native-symbol-list requires Rs)
+      (native-exports Xs) (native-metadata-list MD)
+      (native-compile-profile P)])
+
+(define native-module-symbol
+  _ X -> X where (symbol? X)
+  F X -> (error "native module declaration field ~A expected a symbol, got: ~S~%" F X))
+
+(define native-source-list
+  [] -> (error "native module declaration requires at least one source~%")
+  Ss -> Ss where (native-string-list? Ss)
+  Ss -> (error "native module declaration sources must be strings, got: ~S~%" Ss))
+
+(define native-string-list?
+  [] -> true
+  [S | Ss] -> (and (string? S) (native-string-list? Ss))
+  _ -> false)
+
+(define native-symbol-list
+  _ [] -> []
+  F [X | Xs] -> [X | (native-symbol-list F Xs)] where (symbol? X)
+  F Xs -> (error "native module declaration field ~A expected symbols, got: ~S~%" F Xs))
+
+(define native-exports
+  infer-all -> infer-all
+  Xs -> (native-symbol-list exports Xs))
+
+(define native-metadata-list
+  [] -> []
+  [M | Ms] -> [(native-metadata M) | (native-metadata-list Ms)]
+  MD -> (error "native module declaration metadata must be symbols, got: ~S~%" MD))
+
+(define native-metadata
+  runtime -> runtime
+  compiletime -> compiletime
+  source-kl -> source-kl
+  M -> (error "native module declaration expected metadata runtime, compiletime, or source-kl, got: ~S~%" M))
+
+(define native-module-declaration-name
+  [module-declaration N _ _ _ _ _ _] -> N)
+
+(define native-module-declaration-mode
+  [module-declaration _ M _ _ _ _ _] -> M)
+
+(define native-module-declaration-sources
+  [module-declaration _ _ Ss _ _ _ _] -> Ss)
+
+(define native-module-declaration-requires
+  [module-declaration _ _ _ Rs _ _ _] -> Rs)
+
+(define native-module-declaration-exports
+  [module-declaration _ _ _ _ Xs _ _] -> Xs)
+
+(define native-module-declaration-metadata
+  [module-declaration _ _ _ _ _ MD _] -> MD)
+
+(define native-module-declaration-profile
+  [module-declaration _ _ _ _ _ _ P] -> P)
+
+(define native-module-declaration-key
+  [module-declaration N M Ss Rs Xs MD P]
+  -> ((foreign scm.shen-scheme-native-key) Ss [N M Rs Xs MD P]))
+
+(define native-module-declaration-module-name
+  D -> (intern (make-string "shen_native_decl_~A"
+                            (native-module-declaration-key D))))
+
+(define native-module-declaration-module-name/mode
+  _ compatible -> skip
+  D sealed -> (native-module-declaration-module-name D))
+
+(define native-module-declaration-scheme-forms
+  D -> (let M (native-module-declaration-mode D)
+         (native-scheme-forms*
+          (native-module-declaration-module-name/mode D M)
+          (native-sources->unit (native-module-declaration-sources D))
+          M
+          (native-module-declaration-exports D)
+          (native-module-declaration-metadata D))))
+
+(define native-module-object-path
+  Dir M -> (make-string "~A/~A.so" Dir M))
+
+(define native-module-declaration-path
+  Dir M -> (make-string "~A/~A.shenmod" Dir M))
+
+(define load-compiled
+  O -> ((foreign scm.shen-scheme-load-compiled) O))
+
+(define native-load-compiled-for-compilation
+  O -> ((foreign scm.shen-scheme-load-compiled-for-compilation) O))
+
+(define native-require-existing-file
+  F _ -> F where ((foreign scm.file-exists?) F)
+  F D -> (error "native module expected ~A to exist: ~A~%" D F))
+
+(define native-require-module-dir
+  [] _ -> skip
+  _ Dir -> (if (= Dir (fail))
+               (error "native module requires need a module directory~%")
+               skip))
+
+(define native-cycle-error
+  M -> (error "native module dependency cycle includes: ~A~%" M))
+
+(define native-load-module-requirements
+  Rs Dir Stack L -> (native-load-module-requirements/with
+                     (function load-compiled)
+                     (function native-load-compiled-for-compilation)
+                     Rs Dir Stack L))
+
+(define native-prepare-module-requirements
+  Rs Dir Stack L
+  -> (do (native-require-module-dir Rs Dir)
+         (native-prepare-module-requirements* Rs Dir Stack L)))
+
+(define native-prepare-module-requirements*
+  [] _ _ L -> L
+  [R | Rs] Dir Stack L
+  -> (let P (native-module-declaration-path Dir R)
+          P (native-require-existing-file P "required module declaration")
+          D (native-read-module-declaration P)
+          L (native-prepare-module/declaration* D Dir Stack L)
+       (native-prepare-module-requirements* Rs Dir Stack L)))
+
+(define native-register-arities
+  [] -> skip
+  [[F A] | As] -> (do (native-register-arities As)
+                       (update-lambda-table F A)))
+
+(define native-sources->unit/with-arities
+  Ss As -> (with-native-compiler-state
+            (freeze (native-sources->unit/with-arities* Ss As))))
+
+(define native-sources->unit/with-arities*
+  Ss As -> (let X (native-expand-forms (native-read-source-forms Ss))
+                O (value *property-vector*)
+                N (native-copy-property-vector O)
+             ((foreign scm.dynamic-wind)
+              (freeze (set *property-vector* N))
+              (freeze
+               (do (native-register-arities As)
+                   (native-source-data->unit (native-process-expanded X))))
+              (freeze (set *property-vector* O)))))
+
+(define native-defun-arity
+  [defun F As _] -> [F (length As)])
+
+(define native-exported-arities
+  KL Xs -> (map (function native-defun-arity)
+                (native-exported-kl KL Xs)))
+
+(define native-prepare-module
+  compatible _ Xs -> (error "native compiler explicit exports require sealed mode, got: ~S~%" Xs)
+    where (not (= Xs infer-all))
+  _ Ss Xs
+  -> (let KL (native-unit-kl (native-sources->unit/with-arities Ss []))
+          CXs (native-validate-exports Xs (native-local-map KL))
+       (native-register-arities (native-exported-arities KL CXs))))
+
+(define native-prepare-module/declaration*
+  [module-declaration N M Ss Rs Xs _ _] Dir Stack L
+  -> (if (element? N Stack)
+         (native-cycle-error N)
+         (if (element? N L)
+             (do (native-prepare-module M Ss Xs) L)
+             (let L (native-prepare-module-requirements
+                      Rs Dir [N | Stack] L)
+               (do (native-prepare-module M Ss Xs)
+                   [N | L])))))
+
+(define native-load-module-requirements/with
+  Ld Rd Rs Dir Stack L
+  -> (do (native-require-module-dir Rs Dir)
+         (native-load-module-requirements*/with Ld Rd Rs Dir Stack L)))
+
+(define native-load-module-requirements*/with
+  _ _ [] _ _ L -> L
+  Ld Rd [R | Rs] Dir Stack L
+  -> (let P (native-module-declaration-path Dir R)
+          P (native-require-existing-file P "required module declaration")
+          D (native-read-module-declaration P)
+          L (load-module/declaration*/with Ld Rd D Dir Stack L)
+       (native-load-module-requirements*/with Ld Rd Rs Dir Stack L)))
+
+(define load-module
+  F Dir -> (load-module/declaration (native-read-module-declaration F) Dir))
+
+(define load-module/declaration
+  D Dir -> (load-module/declaration* D Dir [] []))
+
+(define load-module/declaration*
+  D Dir Stack L -> (load-module/declaration*/with
+                    (function load-compiled)
+                    (function native-load-compiled-for-compilation)
+                    D Dir Stack L))
+
+(define load-module/declaration*/with
+  Ld Rd
+  [module-declaration M _ _ Rs _ _ _] Dir Stack L
+  -> (if (element? M Stack)
+         (native-cycle-error M)
+         (if (element? M L)
+             (let O (native-module-object-path Dir M)
+                  O (native-require-existing-file O "module object")
+               (do (Rd O) L))
+             (let L (native-load-module-requirements/with
+                      Ld Rd Rs Dir [M | Stack] L)
+                  O (native-module-object-path Dir M)
+                  O (native-require-existing-file O "module object")
+               (do (Ld O) [M | L])))))
+
+)

--- a/src/native-source.shen
+++ b/src/native-source.shen
@@ -1,0 +1,250 @@
+\* Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(package shen-scheme
+ [release debug wpo unsafe
+  define defun defprolog declare defmacro datatype synonyms package
+  native-unit runtime compiletime source-kl quote eval update-lambda-table
+  _scm.prefix-op scm.dynamic-wind scm.hashtable-copy]
+
+(set *native-compiler-state-depth* 0)
+
+(define native-copy-property-vector
+  D -> ((foreign scm.hashtable-copy) D true))
+
+(define with-native-compiler-state
+  F -> (F) where (> (value *native-compiler-state-depth*) 0)
+  F -> (let Old (value *property-vector*)
+            New (native-copy-property-vector Old)
+            Macros (value *macros*)
+            SigF (value shen.*sigf*)
+            Synonyms (value shen.*synonyms*)
+            Demod (value shen.*demodulation-function*)
+            Datatypes (value shen.*datatypes*)
+            AllDatatypes (value shen.*alldatatypes*)
+            UserDefs (value shen.*userdefs*)
+         ((foreign scm.dynamic-wind)
+          (freeze
+           (do (set *property-vector* New)
+               (set *native-compiler-state-depth* 1)))
+          F
+          (freeze
+           (do (set *property-vector* Old)
+               (set *macros* Macros)
+               (set shen.*sigf* SigF)
+               (set shen.*synonyms* Synonyms)
+               (set shen.*demodulation-function* Demod)
+               (set shen.*datatypes* Datatypes)
+               (set shen.*alldatatypes* AllDatatypes)
+               (set shen.*userdefs* UserDefs)
+               (set *native-compiler-state-depth* 0))))))
+
+(define native-scheme-path
+  O -> (@s O ".scm"))
+
+(define native-compile-profile
+  release -> release
+  debug -> debug
+  wpo -> wpo
+  unsafe -> unsafe
+  "release" -> release
+  "debug" -> debug
+  "wpo" -> wpo
+  "unsafe" -> unsafe
+  P -> (error "native compiler expected profile release, debug, wpo, or unsafe, got: ~S~%" P))
+
+(define native-compile-profile-options
+  P -> (native-compile-profile-options* (native-compile-profile P)))
+
+(define native-compile-profile-options*
+  release -> [2 0 false false false]
+  debug -> [2 2 true true false]
+  wpo -> [2 0 false false true]
+  unsafe -> [3 0 false false false])
+
+(define native-compile-options
+  -> (native-compile-profile-options release))
+
+(define native-effective-wpo?
+  _ true -> true
+  [_ _ _ _ WPO] _ -> WPO)
+
+(define read-file-unprocessed
+  F -> (let Bs (read-file-as-bytelist F)
+            Fs (trap-error (compile (/. X (shen.<s-exprs> X)) Bs)
+                           (/. E (shen.reader-error (value shen.*residue*))))
+         Fs))
+
+(define native-shen->kl
+  [define F | _] -> (error "~A is not a legitimate function name~%" F)
+    where (shen.sysfunc? F)
+  [define F | Rs] -> (shen.shendef->kldef F Rs))
+
+(define native-init->kl
+  F -> (shen.shen->kl-h F))
+
+(define native-define-type-table
+  [define F { | X] -> [(shen.typetable [define F { | X])]
+  _ -> [])
+
+(define native-type-table
+  Fs -> (mapcan (function native-define-type-table) Fs))
+
+(define native-type-declaration-form
+  [F T] -> [(_scm.prefix-op declare) [quote F] [quote T]])
+
+(define native-type-declaration-forms
+  Ts -> (map (function native-type-declaration-form) Ts))
+
+(define native-eval-form
+  F -> [(_scm.prefix-op eval) [quote F]])
+
+(define native-raw-compiletime-form
+  [define | _] -> []
+  [defprolog | _] -> []
+  [declare F T] -> [(native-type-declaration-form [F T])]
+  [declare | X] -> (error "native compiler expected top-level declare with a name and type, got: ~S~%"
+                          [declare | X])
+  [defmacro N | Rs] -> [(native-eval-form [defmacro N | Rs])]
+  [defmacro | X] -> (error "native compiler expected top-level defmacro with a name and rules, got: ~S~%"
+                           [defmacro | X])
+  [datatype N | Rs] -> [(native-eval-form [datatype N | Rs])]
+  [datatype | X] -> (error "native compiler expected top-level datatype with a name and rules, got: ~S~%"
+                           [datatype | X])
+  [synonyms | X] -> [(native-eval-form [synonyms | X])]
+  _ -> [])
+
+(define native-raw-compiletime-forms
+  Fs -> (mapcan (function native-raw-compiletime-form) Fs))
+
+(define native-first-compiletime-forms
+  [] -> []
+  [F | Fs] -> (let CT (native-raw-compiletime-form F)
+                (if (= [] CT)
+                    (native-first-compiletime-forms Fs)
+                    CT)))
+
+(define native-compiletime-form
+  R Xs -> (let CT (native-raw-compiletime-form R)
+            (if (= [] CT)
+                (native-first-compiletime-forms Xs)
+                CT)))
+
+(define native-package-forms
+  [] -> []
+  [[native-package N Xs Fs] | Ps]
+  -> [[(_scm.prefix-op shen.record-external) [quote N] [quote Xs]]
+      [(_scm.prefix-op shen.record-internal) [quote N] [quote Xs] [quote Fs]]
+      | (native-package-forms Ps)])
+
+(define native-expand-forms
+  Fs -> (native-expand-forms* Fs [] [] []))
+
+(define native-macroexpanded-form
+  [native-macroexpanded F _] -> F)
+
+(define native-macroexpanded-steps
+  [native-macroexpanded _ Fs] -> Fs)
+
+(define native-macroexpand
+  F -> (let Ms (map (/. X (tl X)) (value *macros*))
+         (native-macroexpand* F Ms Ms [])))
+
+(define native-macroexpand*
+  F [] _ Xs -> [native-macroexpanded F (reverse Xs)]
+  F [M | Ms] All Xs
+  -> (let X (shen.walk M F)
+       (if (= F X)
+           (native-macroexpand* F Ms All Xs)
+           (native-macroexpand* X All All [X | Xs]))))
+
+(define native-expand-forms*
+  [] Xs CTs Ps -> [native-expanded (reverse Xs) (reverse CTs)
+                  (native-package-forms (reverse Ps))]
+  [[package null _ | Bs] | Fs] Xs CTs Ps
+  -> (native-expand-forms* (append Bs Fs) Xs CTs Ps)
+  [[package N E | Bs] | Fs] Xs CTs Ps
+  -> (let Es (eval E)
+          Qs (shen.package-symbols (str N) Es Bs)
+       (do (shen.record-external N Es)
+           (shen.record-internal N Es Bs)
+           (native-expand-forms* (append Qs Fs) Xs CTs [[native-package N Es Bs] | Ps])))
+  [[package | X] | _] _ _ _
+  -> (error "native compiler expected top-level package with a name and externals, got: ~S~%"
+            [package | X])
+  [F | Fs] Xs CTs Ps
+  -> (let MX (native-macroexpand F)
+          M (native-macroexpanded-form MX)
+          Ms (native-macroexpanded-steps MX)
+       (if (shen.packaged? M)
+           (native-expand-forms* [M | Fs] Xs CTs Ps)
+           (native-expand-forms* Fs [M | Xs]
+                                 [(native-compiletime-form F (append Ms [M])) | CTs] Ps))))
+
+(define native-process-expanded
+  [native-expanded Xs CTs Ps]
+  -> (do (shen.find-arities Xs)
+         (let Ts (shen.find-types Xs)
+           [native-source-data
+            (map (/. X (shen.process-applications X Ts)) Xs)
+            (mapcan (/. X X) CTs)
+            Ps])))
+
+(define native-read-source
+  S -> (native-read-sources [S]))
+
+(define native-read-sources
+  Ss -> (native-process-expanded (native-expand-forms (native-read-source-forms Ss))))
+
+(define native-read-source-forms
+  [] -> []
+  [S | Ss] -> (append (read-file-unprocessed S) (native-read-source-forms Ss)))
+
+(define native-processed-defines
+  [] -> []
+  [[define F | Rs] | Fs] -> [[define F | Rs] | (native-processed-defines Fs)]
+  [_ | Fs] -> (native-processed-defines Fs))
+
+(define native-last-defines
+  Ds -> (reverse (native-last-defines* (reverse Ds) [])))
+
+(define native-last-defines*
+  [] _ -> []
+  [[define F | _] | Ds] Seen -> (native-last-defines* Ds Seen)
+    where (element? F Seen)
+  [[define F | Rs] | Ds] Seen
+  -> [[define F | Rs] | (native-last-defines* Ds [F | Seen])])
+
+(define native-processed-inits
+  [] -> []
+  [[define | _] | Fs] -> (native-processed-inits Fs)
+  [[declare | _] | Fs] -> (native-processed-inits Fs)
+  [[F | Rs] | Fs] -> [[F | Rs] | (native-processed-inits Fs)]
+  [_ | Fs] -> (native-processed-inits Fs))
+
+(define native-forms->unit
+  Fs CT Ps -> (let All (native-processed-defines Fs)
+                   Ds (native-last-defines All)
+                   KL (map (function native-shen->kl) Ds)
+                   Is (map (function native-init->kl) (native-processed-inits Fs))
+                   Ts (native-type-declaration-forms (native-type-table All))
+                [native-unit KL Is (append Ts CT)
+                 Ps]))
+
+(define native-unit-kl
+  [native-unit KL _ _ _] -> KL)
+
+(define native-arity-form
+  [defun F As _] -> [(_scm.prefix-op update-lambda-table) [quote F] (length As)])
+
+(define native-source->unit
+  S -> (native-sources->unit [S]))
+
+(define native-sources->unit
+  Ss -> (with-native-compiler-state
+         (freeze (native-source-data->unit (native-read-sources Ss)))))
+
+(define native-source-data->unit
+  [native-source-data Fs CT Ps] -> (native-forms->unit Fs CT Ps))
+
+)

--- a/src/overrides.shen
+++ b/src/overrides.shen
@@ -106,6 +106,9 @@
 (define shen.char-stinput? S -> false)
 (define shen.char-stoutput? S -> false)
 
+(define shen.read-unit-string
+  _ -> (error "character input streams are not supported~%"))
+
 \* factorise *\
 
 \\ Branches are pushed into a stack instead of being evaluated

--- a/src/primitives.scm
+++ b/src/primitives.scm
@@ -119,6 +119,180 @@
         (function-name scm-expr)
         result)))
 
+(define (shen-scheme-write-forms scheme-file forms include-chez-import?)
+  (when (file-exists? scheme-file)
+    (delete-file scheme-file))
+  (call-with-output-file scheme-file
+    (lambda (out)
+      (when include-chez-import?
+        (display "(import (chezscheme))" out)
+        (newline out)
+        (newline out))
+      (let loop ((forms forms))
+        (unless (null? forms)
+          (pretty-print (car forms) out)
+          (newline out)
+          (loop (cdr forms)))))))
+
+(define (shen-scheme-write-native-forms scheme-file forms)
+  (shen-scheme-write-forms scheme-file forms #t))
+
+(define (shen-scheme-compile-file-message?)
+  (not (shen-global-get '*hush* (lambda (_) #f))))
+
+(define (shen-scheme-compile-scheme-file scheme-file object optimize debug inspector source-info wpo)
+  (parameterize ([optimize-level optimize]
+                 [debug-level debug]
+                 [generate-inspector-information inspector]
+                 [generate-procedure-source-information source-info]
+                 [generate-wpo-files wpo]
+                 [compile-file-message (shen-scheme-compile-file-message?)])
+    (compile-file scheme-file object))
+  object)
+
+(define (shen-scheme-compile-native-forms scheme-file object forms optimize debug inspector source-info wpo)
+  (shen-scheme-write-native-forms scheme-file forms)
+  (shen-scheme-compile-scheme-file scheme-file object optimize debug inspector source-info wpo))
+
+(define (shen-scheme-compile-native-forms-direct object forms optimize debug inspector source-info wpo)
+  (parameterize ([optimize-level optimize]
+                 [debug-level debug]
+                 [generate-inspector-information inspector]
+                 [generate-procedure-source-information source-info]
+                 [generate-wpo-files wpo]
+                 [compile-file-message (shen-scheme-compile-file-message?)])
+    (compile-to-file (cons '(import (chezscheme)) forms) object))
+  object)
+
+(define (shen-scheme-parent-directory directory)
+  (let ((len (string-length directory)))
+    (let loop ((i (- len 1)))
+      (cond ((<= i 0) #f)
+            ((char=? (string-ref directory i) #\/)
+             (substring directory 0 i))
+            (else (loop (- i 1)))))))
+
+(define (shen-scheme-ensure-directory-path directory)
+  (unless (file-exists? directory)
+    (let ((parent (shen-scheme-parent-directory directory)))
+      (when parent
+        (shen-scheme-ensure-directory-path parent)))
+    (mkdir directory)))
+
+(define (shen-scheme-replace-suffix filename suffix)
+  (let* ((len (string-length filename))
+         (dot-index
+          (let loop ((i (- len 1)))
+            (cond ((< i 0) #f)
+                  ((char=? (string-ref filename i) #\.) i)
+                  (else (loop (- i 1)))))))
+    (if dot-index
+        (string-append (substring filename 0 dot-index) suffix)
+        (string-append filename suffix))))
+
+(define (shen-scheme-native-app-module-program-forms module-forms)
+  (if (null? module-forms)
+      '()
+      (let ((module-form (car module-forms)))
+        (cons module-form
+              (cons `(import ,(cadr module-form))
+                    (shen-scheme-native-app-module-program-forms
+                     (cdr module-forms)))))))
+
+(define (shen-scheme-compile-native-app root-dir module-forms program-forms object optimize debug inspector source-info wpo)
+  (shen-scheme-ensure-directory-path root-dir)
+  (let* ((program-file (string-append root-dir "/main.ss"))
+         (program-object (if wpo
+                             (string-append root-dir "/main.so")
+                             object))
+         (program-wpo (shen-scheme-replace-suffix program-object ".wpo")))
+    (shen-scheme-write-forms program-file
+                             (append
+                              '((import (chezscheme) (shen-scheme runtime)))
+                              (shen-scheme-native-app-module-program-forms
+                               module-forms)
+                              program-forms)
+                             #f)
+    (parameterize ([optimize-level optimize]
+                   [debug-level debug]
+                   [generate-inspector-information inspector]
+                   [generate-procedure-source-information source-info]
+                   [generate-wpo-files wpo]
+                   [compile-file-message (shen-scheme-compile-file-message?)]
+                   [library-directories
+                    (cons (cons (get-shen-scheme-home-path)
+                                (get-shen-scheme-home-path))
+                          (library-directories))])
+      (compile-program program-file program-object)
+      (if wpo
+          (list object (compile-whole-program program-wpo object))
+          (list object '())))))
+
+(define shen-scheme-native-load-init (make-parameter #t))
+
+(define (shen-scheme-native-load-init?)
+  (shen-scheme-native-load-init))
+
+(define (shen-scheme-load-compiled object)
+  (load object)
+  object)
+
+(define (shen-scheme-load-compiled-for-compilation object)
+  (parameterize ([shen-scheme-native-load-init #f])
+    (load object))
+  object)
+
+(define shen-scheme-fnv64-offset 14695981039346656037)
+(define shen-scheme-fnv64-prime 1099511628211)
+(define shen-scheme-fnv64-modulus (expt 2 64))
+
+(define (shen-scheme-fnv64-update hash byte)
+  (modulo (* (bitwise-xor hash byte) shen-scheme-fnv64-prime)
+          shen-scheme-fnv64-modulus))
+
+(define (shen-scheme-hash-bytes bytes seed)
+  (let loop ((bytes bytes)
+             (hash seed))
+    (if (null? bytes)
+        hash
+        (loop (cdr bytes)
+              (shen-scheme-fnv64-update hash (car bytes))))))
+
+(define (shen-scheme-hash-string string seed)
+  (let ((len (string-length string)))
+    (let loop ((i 0)
+               (hash seed))
+      (if (= i len)
+          hash
+          (loop (+ i 1)
+                (shen-scheme-fnv64-update hash (char->integer (string-ref string i))))))))
+
+(define (shen-scheme-hash->hex hash)
+  (let ((hex (number->string hash 16)))
+    (string-append (make-string (- 16 (string-length hex)) #\0) hex)))
+
+(define (shen-scheme-file-hash filename)
+  (shen-scheme-hash->hex
+   (shen-scheme-hash-bytes
+    (read-file-as-bytelist filename)
+    shen-scheme-fnv64-offset)))
+
+(define (shen-scheme-native-source-key source)
+  (list (full-path-for-file source) (shen-scheme-file-hash source)))
+
+(define (shen-scheme-native-key sources options)
+  (shen-scheme-hash->hex
+   (shen-scheme-hash-string
+    (call-with-string-output-port
+     (lambda (out)
+       (write (list (map shen-scheme-native-source-key sources) options) out)))
+    shen-scheme-fnv64-offset)))
+
+(define (shen-scheme-delete-file-if-exists filename)
+  (when (file-exists? filename)
+    (delete-file filename))
+  #t)
+
 ;; Streams and I/O
 ;;
 

--- a/src/shen-scheme-extensions.shen
+++ b/src/shen-scheme-extensions.shen
@@ -11,17 +11,299 @@
          ((foreign scm.exit) 1))
   Other -> (shen.x.launcher.default-handle-result Other))
 
+(define shen-scheme.profile-help-text
+  -> "Profiles:
+  release  Safe optimized native compilation. This is the default.
+  debug    Keeps debug and source information.
+  wpo      Enables Chez WPO sidecar generation; app builds produce WPO output.
+  unsafe   Uses Chez optimize-level 3.
+
+--profile unsafe uses Chez optimize-level 3. Chez generates unsafe code at this
+level. Incorrect type or bounds assumptions can cause crashes or memory
+corruption. Use only for trusted, well-tested code.
+")
+
+(define shen-scheme.help-text
+  Exe -> (@s (shen.x.launcher.help-text Exe)
+"
+
+    compile <SOURCE> -o <OBJECT> [--emit-scheme <SCHEME>] [--mode compatible|sealed] [--profile release|debug|wpo|unsafe]
+        Compiles a supported Shen source file to a Chez object file.
+
+    load-compiled <OBJECT>
+        Loads an object produced by a native compilation command.
+
+    compile-module <DECLARATION> -o <OBJECT> [--emit-scheme <SCHEME>] [--module-dir <DIR>]
+        Compiles a Shen-readable native module declaration to a Chez object file.
+
+    load-module <DECLARATION> --module-dir <DIR>
+        Loads a compiled native module and its required modules from DIR.
+
+    build-app <MAIN> [--module <SOURCE> ...] -o <OBJECT> [--wpo] [--profile release|debug|wpo|unsafe]
+        Builds a Shen application object from generated Chez libraries.
+        WPO incorporates the generated application libraries; the resulting
+        object still requires the matching Shen/Scheme runtime.
+
+    build-module-app <DECLARATION> --module-dir <DIR> -o <OBJECT> [--wpo] [--profile release|debug|wpo|unsafe]
+        Builds an application object from a closed native module declaration graph."))
+
+(define shen-scheme.compile-help-text
+  Exe -> (@s "Usage: " Exe
+             " compile <SOURCE> -o <OBJECT> [--emit-scheme <SCHEME>] [--mode compatible|sealed] [--profile release|debug|wpo|unsafe]
+
+Compiles a Shen source file to a Chez object file. Top-level package forms and
+arbitrary Shen expression effects are supported. Definitions are hoisted;
+effects, including effects inside packages, preserve their relative source
+order and execute after definitions and metadata when the object is loaded.
+Foreign Scheme define, import, module, and library forms are not supported as
+native initializers.
+
+Compatible mode is the default. Sealed mode binds intra-file calls locally and
+therefore does not observe later redefinitions of same-file helper functions.
+By default, generated Scheme forms are compiled directly. Use --emit-scheme to
+write the generated Scheme file for debugging before compiling it.
+"
+             (shen-scheme.profile-help-text)))
+
+(define shen-scheme.load-compiled-help-text
+  Exe -> (@s "Usage: " Exe
+             " load-compiled <OBJECT>
+
+Loads an object produced by compile, compile-module, build-app, or
+build-module-app.
+"))
+
+(define shen-scheme.compile-module-help-text
+  Exe -> (@s "Usage: " Exe
+             " compile-module <DECLARATION> -o <OBJECT> [--emit-scheme <SCHEME>] [--module-dir <DIR>]
+
+Compiles a Shen-readable native module declaration to a Chez object file.
+
+The declaration file is parsed as raw Shen data without macro expansion. The
+module declaration compiler supports explicit source lists and static
+dependencies. Standalone module compilation requires sealed mode for explicit
+exports. With --module-dir, symbolic requires are resolved as
+<DIR>/<module-name>.shenmod and analyzed from source without loading their
+compiled objects, installing ordinary definitions, or running initializers.
+Dependency macros must be self-contained or use helpers already loaded in the
+compiler, and their transformer names must not collide with live bindings.
+Foreign Scheme definition-context forms are not supported as native
+initializers.
+"))
+
+(define shen-scheme.load-module-help-text
+  Exe -> (@s "Usage: " Exe
+             " load-module <DECLARATION> --module-dir <DIR>
+
+Loads a compiled native module and its transitive required modules from DIR.
+Module names resolve as <DIR>/<module-name>.shenmod and
+<DIR>/<module-name>.so.
+"))
+
+(define shen-scheme.build-app-help-text
+  Exe -> (@s "Usage: " Exe
+             " build-app <MAIN> [--module <SOURCE> ...] -o <OBJECT> [--wpo] [--profile release|debug|wpo|unsafe]
+
+Builds an application object from supported Shen source files.
+
+Module sources are compiled before MAIN. Later sources can statically call
+functions from earlier sources. Compile-time forms are available while the app
+is built, but dependency macros cannot call ordinary helpers defined only in an
+earlier source and their transformer names must not collide with live bindings.
+Compile-time forms are not replayed when a raw source app object is loaded.
+Foreign Scheme definition-context forms are not supported as native
+initializers.
+With --wpo, Chez whole-program optimization incorporates all generated
+application libraries. The object still requires the matching Shen/Scheme
+runtime.
+"
+             (shen-scheme.profile-help-text)))
+
+(define shen-scheme.build-module-app-help-text
+  Exe -> (@s "Usage: " Exe
+             " build-module-app <DECLARATION> --module-dir <DIR> -o <OBJECT> [--wpo] [--profile release|debug|wpo|unsafe]
+
+Builds an application object from a closed native module declaration graph.
+Dependencies are resolved from --module-dir as <DIR>/<module-name>.shenmod.
+Descriptor exports form the static native boundary between generated libraries,
+and descriptor compile-time metadata is replayed when the app is loaded.
+Dependencies use static app bindings. The command-line profile controls the app
+build; descriptor mode and profile apply to standalone compile-module builds.
+Direct requirements that export the same function are rejected.
+The graph is analyzed in topological order as one compiler environment.
+Dependency macros must be self-contained or use helpers already loaded in the
+compiler, and their transformer names must not collide with live bindings.
+Foreign Scheme definition-context forms are not supported as native
+initializers.
+"
+             (shen-scheme.profile-help-text)))
+
+(define shen-scheme.parse-compile-args
+  [Source | Args] -> (shen-scheme.parse-compile-options Args Source (fail) (fail) compatible release)
+  _ -> [error])
+
+(define shen-scheme.parse-compile-options
+  [] Source Object Scheme Mode Profile -> [ok Source Object Scheme Mode Profile]
+  ["-o" Object | Rest] Source _ Scheme Mode Profile
+  -> (shen-scheme.parse-compile-options Rest Source Object Scheme Mode Profile)
+  ["--emit-scheme" Scheme | Rest] Source Object _ Mode Profile
+  -> (shen-scheme.parse-compile-options Rest Source Object Scheme Mode Profile)
+  ["--mode" Mode | Rest] Source Object Scheme _ Profile
+  -> (shen-scheme.parse-compile-options Rest Source Object Scheme Mode Profile)
+  ["--profile" Profile | Rest] Source Object Scheme Mode _
+  -> (shen-scheme.parse-compile-options Rest Source Object Scheme Mode Profile)
+  [Arg | _] _ _ _ _ _ -> [error Arg])
+
+(define shen-scheme.compile-command*
+  Exe [ok _ Object _ _ _] -> [error (shen-scheme.compile-help-text Exe)]
+    where (= Object (fail))
+  _ [ok Source Object Scheme Mode Profile]
+  -> (let Options (shen-scheme.native-compile-profile-options Profile)
+       (if (= Scheme (fail))
+           (do (shen-scheme.compile-file/options/mode Source Object Options Mode)
+               [success])
+           (do (shen-scheme.compile-file/emit/options/mode Source Object Scheme Options Mode)
+               [success])))
+  Exe _ -> [error (shen-scheme.compile-help-text Exe)])
+
+(define shen-scheme.compile-command
+  Exe ["--help"] -> [show-help (shen-scheme.compile-help-text Exe)]
+  Exe Args -> (shen-scheme.compile-command* Exe (shen-scheme.parse-compile-args Args)))
+
+(define shen-scheme.load-compiled-command
+  Exe ["--help"] -> [show-help (shen-scheme.load-compiled-help-text Exe)]
+  _ [Object] -> (do (shen-scheme.load-compiled Object)
+                    [success])
+  Exe _ -> [error (shen-scheme.load-compiled-help-text Exe)])
+
+(define shen-scheme.parse-compile-module-args
+  [Declaration | Args] -> (shen-scheme.parse-compile-module-options
+                           Args Declaration (fail) (fail) (fail))
+  _ -> [error])
+
+(define shen-scheme.parse-compile-module-options
+  [] Declaration Object Scheme ModuleDir
+  -> [ok Declaration Object Scheme ModuleDir]
+  ["-o" Object | Rest] Declaration _ Scheme ModuleDir
+  -> (shen-scheme.parse-compile-module-options Rest Declaration Object Scheme ModuleDir)
+  ["--emit-scheme" Scheme | Rest] Declaration Object _ ModuleDir
+  -> (shen-scheme.parse-compile-module-options Rest Declaration Object Scheme ModuleDir)
+  ["--module-dir" ModuleDir | Rest] Declaration Object Scheme _
+  -> (shen-scheme.parse-compile-module-options Rest Declaration Object Scheme ModuleDir)
+  [Arg | _] _ _ _ _ -> [error Arg])
+
+(define shen-scheme.compile-module-command*
+  Exe [ok _ Object _ _] -> [error (shen-scheme.compile-module-help-text Exe)]
+    where (= Object (fail))
+  _ [ok Declaration Object Scheme ModuleDir]
+  -> (do (shen-scheme.compile-module Declaration Object)
+         [success])
+    where (and (= Scheme (fail)) (= ModuleDir (fail)))
+  _ [ok Declaration Object Scheme ModuleDir]
+  -> (do (shen-scheme.compile-module/emit Declaration Object Scheme)
+         [success])
+    where (= ModuleDir (fail))
+  _ [ok Declaration Object Scheme ModuleDir]
+  -> (do (shen-scheme.compile-module/in-dir Declaration Object ModuleDir)
+         [success])
+    where (= Scheme (fail))
+  _ [ok Declaration Object Scheme ModuleDir]
+  -> (do (shen-scheme.compile-module/emit/in-dir Declaration Object Scheme ModuleDir)
+         [success])
+  Exe _ -> [error (shen-scheme.compile-module-help-text Exe)])
+
+(define shen-scheme.compile-module-command
+  Exe ["--help"] -> [show-help (shen-scheme.compile-module-help-text Exe)]
+  Exe Args -> (shen-scheme.compile-module-command*
+               Exe (shen-scheme.parse-compile-module-args Args)))
+
+(define shen-scheme.load-module-command
+  Exe ["--help"] -> [show-help (shen-scheme.load-module-help-text Exe)]
+  _ [Declaration "--module-dir" ModuleDir]
+  -> (do (shen-scheme.load-module Declaration ModuleDir)
+         [success])
+  Exe _ -> [error (shen-scheme.load-module-help-text Exe)])
+
+(define shen-scheme.parse-build-app-args
+  [] Modules Object Wpo Profile -> [ok (reverse Modules) Object Wpo Profile]
+  ["--module" Module | Rest] Modules Object Wpo Profile
+  -> (shen-scheme.parse-build-app-args Rest [Module | Modules] Object Wpo Profile)
+  ["-o" Object | Rest] Modules _ Wpo Profile
+  -> (shen-scheme.parse-build-app-args Rest Modules Object Wpo Profile)
+  ["--wpo" | Rest] Modules Object _ Profile
+  -> (shen-scheme.parse-build-app-args Rest Modules Object true Profile)
+  ["--profile" Profile | Rest] Modules Object Wpo _
+  -> (shen-scheme.parse-build-app-args Rest Modules Object Wpo Profile)
+  [Arg | _] _ _ _ _ -> [error Arg])
+
+(define shen-scheme.build-app-command*
+  Exe _ [ok _ Object _ _] -> [error (shen-scheme.build-app-help-text Exe)]
+    where (= Object (fail))
+  _ Main [ok Modules Object Wpo Profile]
+  -> (do (shen-scheme.build-app/emit/options
+          Main Modules Object "_build/native-app"
+          (shen-scheme.native-compile-profile-options Profile) Wpo)
+         [success])
+  Exe _ _ -> [error (shen-scheme.build-app-help-text Exe)])
+
+(define shen-scheme.build-app-command
+  Exe ["--help"] -> [show-help (shen-scheme.build-app-help-text Exe)]
+  Exe [Main | Args] -> (shen-scheme.build-app-command*
+                        Exe Main
+                        (shen-scheme.parse-build-app-args Args [] (fail) false release))
+  Exe _ -> [error (shen-scheme.build-app-help-text Exe)])
+
+(define shen-scheme.parse-build-module-app-args
+  [] ModuleDir Object Wpo Profile -> [ok ModuleDir Object Wpo Profile]
+  ["--module-dir" ModuleDir | Rest] _ Object Wpo Profile
+  -> (shen-scheme.parse-build-module-app-args Rest ModuleDir Object Wpo Profile)
+  ["-o" Object | Rest] ModuleDir _ Wpo Profile
+  -> (shen-scheme.parse-build-module-app-args Rest ModuleDir Object Wpo Profile)
+  ["--wpo" | Rest] ModuleDir Object _ Profile
+  -> (shen-scheme.parse-build-module-app-args Rest ModuleDir Object true Profile)
+  ["--profile" Profile | Rest] ModuleDir Object Wpo _
+  -> (shen-scheme.parse-build-module-app-args Rest ModuleDir Object Wpo Profile)
+  [Arg | _] _ _ _ _ -> [error Arg])
+
+(define shen-scheme.build-module-app-command*
+  Exe _ [ok ModuleDir _ _ _] -> [error (shen-scheme.build-module-app-help-text Exe)]
+    where (= ModuleDir (fail))
+  Exe _ [ok _ Object _ _] -> [error (shen-scheme.build-module-app-help-text Exe)]
+    where (= Object (fail))
+  _ Declaration [ok ModuleDir Object true Profile]
+  -> (do (shen-scheme.build-module-app/wpo/profile Declaration ModuleDir Object Profile)
+         [success])
+  _ Declaration [ok ModuleDir Object false Profile]
+  -> (do (shen-scheme.build-module-app/profile Declaration ModuleDir Object Profile)
+         [success])
+  Exe _ _ -> [error (shen-scheme.build-module-app-help-text Exe)])
+
+(define shen-scheme.build-module-app-command
+  Exe ["--help"] -> [show-help (shen-scheme.build-module-app-help-text Exe)]
+  Exe [Declaration | Args] -> (shen-scheme.build-module-app-command*
+                               Exe Declaration
+                               (shen-scheme.parse-build-module-app-args
+                                Args (fail) (fail) false release))
+  Exe _ -> [error (shen-scheme.build-module-app-help-text Exe)])
+
 (define shen-scheme.run-shen
-  Args -> (shen-scheme.handle-launcher-result
-           (shen.x.launcher.launch-shen Args)))
+  [Exe "--help"] -> (shen-scheme.handle-launcher-result [show-help (shen-scheme.help-text Exe)])
+  [Exe "compile" | Args]
+  -> (shen-scheme.handle-launcher-result (shen-scheme.compile-command Exe Args))
+  [Exe "load-compiled" | Args]
+  -> (shen-scheme.handle-launcher-result (shen-scheme.load-compiled-command Exe Args))
+  [Exe "compile-module" | Args]
+  -> (shen-scheme.handle-launcher-result (shen-scheme.compile-module-command Exe Args))
+  [Exe "load-module" | Args]
+  -> (shen-scheme.handle-launcher-result (shen-scheme.load-module-command Exe Args))
+  [Exe "build-app" | Args]
+  -> (shen-scheme.handle-launcher-result (shen-scheme.build-app-command Exe Args))
+  [Exe "build-module-app" | Args] -> (shen-scheme.handle-launcher-result
+                                      (shen-scheme.build-module-app-command Exe Args))
+  Args -> (shen-scheme.handle-launcher-result (shen.x.launcher.launch-shen Args)))
 
 (define shen-scheme.find-library
   Name -> ((foreign scm.string-append) ((foreign scm.get-shen-scheme-home-path)) "/libraries/" Name))
 
 (define thread
   Lazy -> ((foreign scm.fork-thread) Lazy))
-
-(update-lambda-table shen-scheme.handle-launcher-result 1)
-(update-lambda-table shen-scheme.run-shen 1)
-(update-lambda-table shen-scheme.find-library 1)
-(update-lambda-table thread 1)

--- a/tests/compiler-tests.shen
+++ b/tests/compiler-tests.shen
@@ -7,6 +7,26 @@
  (_scm.force-boolean true)
  true)
 
+(set _scm.*native-mode* compatible)
+(set _scm.*native-local-map* [])
+
+(assert-equal
+ (trap-error
+  (_scm.with-native-context
+   sealed
+   [[native-context-test shen_native_context_test]]
+   (freeze (/ 1 0)))
+  (/. E failed))
+ failed)
+
+(assert-equal
+ (_scm.native-mode)
+ compatible)
+
+(assert-equal
+ (_scm.native-local-map)
+ [])
+
 (assert-equal
  (_scm.force-boolean false) false)
 
@@ -103,6 +123,36 @@
 (assert-equal
  (_scm.kl->scheme [blah 1 2])
  [(_scm.prefix-op blah) 1 2])
+
+(assert-equal
+ (_scm.with-native-context sealed [[foo local-foo] [bar local-bar]]
+   (freeze (_scm.kl->scheme [defun foo [X] [bar X]])))
+ [define [local-foo X] [local-bar X]])
+
+(assert-equal
+ (_scm.with-native-context sealed [[bar local-bar]]
+   (freeze (_scm.compile-expression [bar 1] [bar])))
+ [bar 1])
+
+(assert-equal
+ (_scm.with-native-context sealed [[bar local-bar]]
+   (freeze (_scm.compile-expression [fn bar] [])))
+ local-bar)
+
+(assert-equal
+ (_scm.with-native-context sealed [[+ local-plus]]
+   (freeze (_scm.compile-expression [+ X 1] [X])))
+ [+ X 1])
+
+(assert-equal
+ (_scm.with-native-context app [[foo local-foo] [bar local-bar]]
+   (freeze (_scm.kl->scheme [defun foo [X] [bar X]])))
+ [define [local-foo X] [local-bar X]])
+
+(assert-equal
+ (_scm.with-native-context app []
+   (freeze (_scm.compile-expression [length X] [X])))
+ [(_scm.prefix-op length) X])
 
 (assert-equal
  (_scm.kl->scheme 1)

--- a/tests/native/app-lib.shen
+++ b/tests/native/app-lib.shen
@@ -1,0 +1,11 @@
+(set *native-app-init-events* [])
+
+(define native-app-helper
+  X -> (+ X 1))
+
+(set *native-app-init-events*
+     (append (value *native-app-init-events*)
+             [(native-app-helper 0)]))
+
+(define native-app-hop
+  X -> (native-app-helper X))

--- a/tests/native/app-main.shen
+++ b/tests/native/app-main.shen
@@ -1,0 +1,21 @@
+(set *native-app-init-events*
+     (append (value *native-app-init-events*)
+             [(native-app-main 1)]))
+
+(define native-app-main
+  X -> (+ (native-app-hop X) 10))
+
+(define native-app-direct
+  X -> (native-app-helper X))
+
+(define native-app-length
+  Xs -> (length Xs))
+
+(define native-app-absvector?
+  -> (absvector? (absvector 1)))
+
+(define native-app-list-equal?
+  -> (= [a list] [a list]))
+
+(define native-app-sysfunc?
+  -> (shen.sysfunc? cons))

--- a/tests/native/call-heavy.shen
+++ b/tests/native/call-heavy.shen
@@ -1,0 +1,45 @@
+\* Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(define native-bench-hop0
+  X -> (+ X 1))
+
+(define native-bench-hop1
+  X -> (native-bench-hop0 X))
+
+(define native-bench-hop2
+  X -> (native-bench-hop1 X))
+
+(define native-bench-hop3
+  X -> (native-bench-hop2 X))
+
+(define native-bench-hop4
+  X -> (native-bench-hop3 X))
+
+(define native-bench-hop5
+  X -> (native-bench-hop4 X))
+
+(define native-bench-hop6
+  X -> (native-bench-hop5 X))
+
+(define native-bench-hop7
+  X -> (native-bench-hop6 X))
+
+(define native-bench-hop8
+  X -> (native-bench-hop7 X))
+
+(define native-bench-hop9
+  X -> (native-bench-hop8 X))
+
+(define native-bench-hop10
+  X -> (native-bench-hop9 X))
+
+(define native-bench-hop11
+  X -> (native-bench-hop10 X))
+
+(define native-bench-entry
+  X -> (native-bench-hop11 X))
+
+(define native-bench-loop
+  0 Acc -> Acc
+  N Acc -> (native-bench-loop (- N 1) (native-bench-entry Acc)))

--- a/tests/native/package-effects-updated.shen
+++ b/tests/native/package-effects-updated.shen
@@ -1,0 +1,2 @@
+(define native.test.pkg.helper
+  X -> (+ X 1000))

--- a/tests/native/package-effects.shen
+++ b/tests/native/package-effects.shen
@@ -1,0 +1,29 @@
+(set *native-package-events* [])
+
+(package native.test.pkg
+  [native-package-main native-package-state *native-package-events*]
+
+(defmacro twice
+  [twice X] -> [* X 2])
+
+(synonyms amount number)
+
+(declare helper [amount --> amount])
+
+(define helper
+  X -> (+ X 1))
+
+(define remember
+  X -> (set *native-package-events*
+            (append (value *native-package-events*) [X])))
+
+(remember (helper 40))
+
+(define native-package-main
+  X -> (twice (helper X)))
+
+(define native-package-state
+  -> (value *native-package-events*)))
+
+(set *native-package-events*
+     (append (value *native-package-events*) [2]))

--- a/tests/native/package-effects.shenmod
+++ b/tests/native/package-effects.shenmod
@@ -1,0 +1,6 @@
+(shen.aot.module
+  (name native.test.package-effects)
+  (mode sealed)
+  (exports)
+  (metadata)
+  (sources "tests/native/package-effects.shen"))

--- a/tests/native/redefinition-compatible-updated.shen
+++ b/tests/native/redefinition-compatible-updated.shen
@@ -1,0 +1,5 @@
+\* Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(define native-compatible-helper
+  X -> (+ X 100))

--- a/tests/native/redefinition-compatible.shen
+++ b/tests/native/redefinition-compatible.shen
@@ -1,0 +1,8 @@
+\* Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(define native-compatible-helper
+  X -> (+ X 1))
+
+(define native-compatible-main
+  X -> (native-compatible-helper X))

--- a/tests/native/redefinition-sealed-updated.shen
+++ b/tests/native/redefinition-sealed-updated.shen
@@ -1,0 +1,5 @@
+\* Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(define native-sealed-helper
+  X -> (+ X 100))

--- a/tests/native/redefinition-sealed.shen
+++ b/tests/native/redefinition-sealed.shen
@@ -1,0 +1,8 @@
+\* Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(define native-sealed-helper
+  X -> (+ X 1))
+
+(define native-sealed-main
+  X -> (native-sealed-helper X))

--- a/tests/native/simple-updated.shen
+++ b/tests/native/simple-updated.shen
@@ -1,0 +1,16 @@
+\* Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(define native-test-add
+  X Y -> (+ X Y 10))
+
+(define native-test-inc
+  X -> (native-test-add X 1))
+
+(define native-test-sumdown
+  0 -> 100
+  X -> (+ X (native-test-sumdown (- X 1))))
+
+(define native-test-map-inc
+  [] -> []
+  [X | Xs] -> [(native-test-inc X) | (native-test-map-inc Xs)])

--- a/tests/native/simple.shen
+++ b/tests/native/simple.shen
@@ -1,0 +1,16 @@
+\* Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(define native-test-add
+  X Y -> (+ X Y))
+
+(define native-test-inc
+  X -> (native-test-add X 1))
+
+(define native-test-sumdown
+  0 -> 0
+  X -> (+ X (native-test-sumdown (- X 1))))
+
+(define native-test-map-inc
+  [] -> []
+  [X | Xs] -> [(native-test-inc X) | (native-test-map-inc Xs)])


### PR DESCRIPTION
## Summary

Adds an explicit, opt-in native AOT compilation path for Shen/Scheme. Shen source files, declared modules, and closed applications can be compiled to Chez object files and loaded into a matching Shen/Scheme process.

The runtime no longer uses a generated `shen.boot`. It starts from the stock Chez boot files and distributes one composite `shen-scheme/runtime.so` containing both the importable `(shen-scheme runtime)` library and the launcher program. `SHEN_SCHEME_RUNTIME=petite` selects a compiler-free runtime that can still load precompiled native artifacts.

Native compilation supports ordinary Shen `package` forms, declarations, compile-time forms, `defprolog`, and arbitrary top-level Shen effects. Definitions are hoisted; metadata and package registrations are installed before remaining initializers execute in source order.

The separate Prolog optimizer experiments are intentionally excluded from this PR.

## Highlights

- Adds `compile`, `load-compiled`, `compile-module`, `load-module`, `build-app`, and `build-module-app`, plus corresponding `shen-scheme` APIs.
- `compatible` mode preserves normal top-level rebinding; `sealed` mode binds calls within a compilation unit for better performance.
- `.shenmod` declarations describe sources, dependencies, exports, metadata, load policy, mode, and profile.
- Dependency analysis is transient: private dependency arities do not leak into callers, while exported arities, packages, macros, datatypes, and synonyms remain available where required.
- Raw-source and descriptor application builders provide static cross-unit boundaries, dependency-ordered initialization, and optional Chez whole-program optimization.
- Direct sources and modules support packages, top-level effects, declarations, macros, datatypes, synonyms, source KLambda, and `defprolog`.
- Native objects are loaded by both the full runtime and a matching compiler-free Petite deployment.
- Build, install, and binary-release layouts now contain stock `petite.boot`, stock `scheme.boot`, and one nested composite `shen-scheme/runtime.so`.
- Adds runnable examples for direct compilation, compatible versus sealed rebinding, packages and effects, module graphs, app builds, WPO, and full-to-Petite deployment.
- Adds a complete native-compilation guide covering the CLI, `.shenmod` format, APIs, metadata semantics, deployment, embedding, benchmarks, and known limitations.
- Port and realistic benchmark runners compare dynamic, compatible, sealed, app, and app-WPO modes with machine-readable output. Vendored port workloads remain byte-for-byte identical to `shen-sources`.

## Current limitations

- Compiled native modules currently support only the `static-only` load policy.
- Dependency macros must be self-contained or use helpers already loaded in the compiler; ordinary helpers from dependency sources are not installed during dependency analysis.
- Macro transformer names share the live compiler namespace and must not collide.
- Foreign Scheme escapes that produce definition-context forms such as `define`, `import`, `module`, or `library` cannot be native initializers. Ordinary foreign Scheme expressions are supported.
- Native outputs are build artifacts specific to the platform, architecture, Chez build, Shen/Scheme runtime, and compilation profile that produced them.

## Documentation

- `README.md` contains the workflow overview and quick start.
- `examples/native/README.md` is a runnable tutorial.
- `docs/native-compilation.md` is the complete reference and deployment guide.

## Validation

Validated locally with:

- `make test-clean-parallel-build`
- `make test`
- `make test-native-examples`
- `make test-runtime-artifact-recovery`
- `make test-external-runtime`
- WPO-on to WPO-off runtime rebuild and sidecar cleanup checks
- `make bench-port-smoke`
- `make bench-realistic-smoke`
- `make install` layout inspection
- binary-release creation, extraction, and documented full/Petite compile-load flows
- `git diff --check`

CI runs the build and tests on macOS, Ubuntu, and Windows.
