### PR TITLE
Add portable Shen modules and enable programmable pattern matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Native AOT compilation for Shen source files and declared modules, including
   top-level `defprolog` and `package` forms and arbitrary top-level Shen
   expression effects.
+- Versioned portable `shen.module` declarations with namespaced Shen/Scheme
+  native-compilation settings.
 - Compatible and sealed compilation modes, build profiles, dependency
   resolution, standalone app builds, and whole-program optimization support.
 - Port-style and realistic benchmark suites comparing dynamic loading,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Shen's programmable-pattern-matching extension, initialized at startup.
 - Native AOT compilation for Shen source files and declared modules, including
   top-level `defprolog` and `package` forms and arbitrary top-level Shen
   expression effects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of maintaining a parallel manual list.
 - Relative `.shenmod` source paths are resolved from the descriptor rather than
   the process working directory.
+- Native module compilation honors per-source `tc+` and `tc-` transitions and
+  emits inline type metadata only for checked sources.
 - Shen/Scheme now starts from the stock Chez boot files and loads a combined
   runtime and launcher object instead of generating a custom `shen.boot`.
   `SHEN_SCHEME_RUNTIME=petite` selects a compiler-free runtime that can still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Shen's programmable-pattern-matching extension, initialized at startup.
+- Shen's programmable-pattern-matching extension, initialized at startup,
+  including native AOT support for handlers used by later source files and
+  dependent modules.
 - Native AOT compilation for Shen source files and declared modules, including
   top-level `defprolog` and `package` forms and arbitrary top-level Shen
   expression effects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Compiler arity registrations are generated from compiled definitions instead
   of maintaining a parallel manual list.
 - Relative `.shenmod` source paths are resolved from the descriptor rather than
-  the process working directory.
+  the process working directory. Portable module declarations require relative
+  source paths and verify the names of required declarations.
 - Native module compilation honors per-source `tc+` and `tc-` transitions and
   emits inline type metadata only for checked sources.
 - Shen/Scheme now starts from the stock Chez boot files and loads a combined

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated kernel to S41.3.
 - Compiler arity registrations are generated from compiled definitions instead
   of maintaining a parallel manual list.
+- Relative `.shenmod` source paths are resolved from the descriptor rather than
+  the process working directory.
 - Shen/Scheme now starts from the stock Chez boot files and loads a combined
   runtime and launcher object instead of generating a custom `shen.boot`.
   `SHEN_SCHEME_RUNTIME=petite` selects a compiler-free runtime that can still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of maintaining a parallel manual list.
 - Relative `.shenmod` source paths are resolved from the descriptor rather than
   the process working directory. Portable module declarations require relative
-  source paths and verify the names of required declarations.
+  source paths and verify the names of required declarations. Module loading
+  uses separate declaration and compiled-object roots.
 - Native module compilation honors per-source `tc+` and `tc-` transitions and
   emits inline type metadata only for checked sources.
 - Shen/Scheme now starts from the stock Chez boot files and loads a combined

--- a/Makefile
+++ b/Makefile
@@ -288,8 +288,7 @@ test-native: $(exe) $(runtime_artifacts)
 .PHONY: test-native-examples
 test-native-examples: $(exe) $(runtime_artifacts)
 	mkdir -p _build/native-examples/modules
-	cp examples/native/modules/native-example.core.shenmod _build/native-examples/modules/
-	cp examples/native/modules/native-example.app.shenmod _build/native-examples/modules/
+	cp examples/native/modules/native-example.* _build/native-examples/modules/
 	./$(exe) compile examples/native/single-file.shen -o _build/native-examples/single-file.so
 	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-examples/single-file.so\")" -e "(if (= (answer 5) 26) ok (error \"native single-file example failed\"))"
 	./$(exe) compile examples/native/binding.shen -o _build/native-examples/compatible.so

--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,11 @@ test-shen: $(exe) $(runtime_artifacts)
 	./$(exe) script scripts/run-shen-tests.shen
 	./$(exe) script tests/kernel-compatibility.shen
 
+.PHONY: test-ppm
+test-ppm: $(exe) $(runtime_artifacts)
+	./$(exe) script scripts/run-programmable-pattern-matching-tests.shen
+	SHEN_SCHEME_RUNTIME=petite ./$(exe) script scripts/run-programmable-pattern-matching-tests.shen
+
 .PHONY: test-compiler
 test-compiler: $(exe) $(runtime_artifacts)
 	./$(exe) script scripts/run-compiler-tests.shen
@@ -349,7 +354,7 @@ test-clean-parallel-build: chez_kernel
 	./$(exe) --version
 
 .PHONY: test
-test: test-shen test-compiler test-native test-native-examples
+test: test-shen test-ppm test-compiler test-native test-native-examples
 
 .PHONY: test-external-runtime
 test-external-runtime: $(exe) $(runtime_artifacts)

--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,10 @@ test-compiler: $(exe) $(runtime_artifacts)
 .PHONY: test-native
 test-native: $(exe) $(runtime_artifacts)
 	mkdir -p _build/native-tests
+	mkdir -p _build/native-tests/module-objects
+	mkdir -p _build/native-tests/module-regression-objects
+	mkdir -p _build/native-tests/nested-modules/native.test
+	mkdir -p _build/native-tests/nested-objects/native.test
 	./$(exe) script scripts/run-native-tests.shen
 	./$(exe) eval -q -e "(shen-scheme.delete-file-if-exists \"_build/native-tests/cli-direct.so.scm\")"
 	./$(exe) compile tests/native/simple.shen -o _build/native-tests/cli-direct.so
@@ -278,10 +282,10 @@ test-native: $(exe) $(runtime_artifacts)
 	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-module-source-kl.so\")" -e "(if (= (native-module-source-kl 41) 42) ok (error \"native CLI module source-kl call failed\"))" -e "(if (= defun (hd (ps native-module-source-kl))) ok (error \"native CLI module source-kl ps failed\"))" -e "(if (= native-module-source-kl (hd (tl (ps native-module-source-kl)))) ok (error \"native CLI module source-kl recorded wrong name\"))" -e "(if (element? native-module-source-kl (value shen.*userdefs*)) ok (error \"native CLI module source-kl userdefs failed\"))"
 	./$(exe) compile-module _build/native-tests/module-no-source-kl.shenmod -o _build/native-tests/cli-module-no-source-kl.so
 	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-module-no-source-kl.so\")" -e "(if (= (native-module-no-source-kl 41) 42) ok (error \"native CLI module no-source-kl call failed\"))" -e "(if (= missing (trap-error (ps native-module-no-source-kl) (/. E missing))) ok (error \"native CLI module no-source-kl leaked ps\"))" -e "(if (not (element? native-module-no-source-kl (value shen.*userdefs*))) ok (error \"native CLI module no-source-kl leaked userdefs\"))"
-	./$(exe) compile-module _build/native-tests/native.test.required.shenmod -o _build/native-tests/native.test.required.so
-	./$(exe) compile-module _build/native-tests/native.test.requirer.shenmod --module-dir _build/native-tests -o _build/native-tests/native.test.requirer.so
-	./$(exe) eval -q -e "(shen-scheme.load-module \"_build/native-tests/native.test.requirer.shenmod\" \"_build/native-tests\")" -e "(if (= (native-module-requirer 32) 42) ok (error \"native CLI module requires failed\"))"
-	./$(exe) load-module _build/native-tests/native.test.requirer.shenmod --module-dir _build/native-tests
+	./$(exe) compile-module _build/native-tests/native.test.required.shenmod -o _build/native-tests/module-objects/native.test.required.so
+	./$(exe) compile-module _build/native-tests/native.test.requirer.shenmod --module-dir _build/native-tests -o _build/native-tests/module-objects/native.test.requirer.so
+	./$(exe) eval -q -e "(shen-scheme.load-module \"_build/native-tests/native.test.requirer.shenmod\" \"_build/native-tests\" \"_build/native-tests/module-objects\")" -e "(if (= (native-module-requirer 32) 42) ok (error \"native CLI module requires failed\"))"
+	./$(exe) load-module _build/native-tests/native.test.requirer.shenmod --object-dir _build/native-tests/module-objects --module-dir _build/native-tests
 	./$(exe) build-module-app _build/native-tests/native.test.app-main.shenmod --module-dir _build/native-tests -o _build/native-tests/cli-module-app-wpo.so --wpo
 	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-tests/cli-module-app-wpo.so\")" -e "(if (= (value *native-module-app-init-events*) [10 11]) ok (error \"native CLI module app initializer order failed\"))" -e "(if (= (native-module-app-main 32) 42) ok (error \"native CLI module app failed\"))" -e "(load \"_build/native-tests/module-app-base-updated.shen\")" -e "(if (= (native-module-app-base 1) 1001) ok (error \"native CLI module app dependency redefine failed\"))" -e "(if (= (native-module-app-main 32) 42) ok (error \"native CLI module app lost direct dependency binding\"))"
 	./$(exe) build-app tests/native/app-main.shen --module tests/native/app-lib.shen -o _build/native-tests/cli-app-wpo.so --wpo
@@ -292,8 +296,7 @@ test-native: $(exe) $(runtime_artifacts)
 
 .PHONY: test-native-examples
 test-native-examples: $(exe) $(runtime_artifacts)
-	mkdir -p _build/native-examples/modules
-	cp examples/native/modules/native-example.* _build/native-examples/modules/
+	mkdir -p _build/native-examples/objects
 	./$(exe) compile examples/native/single-file.shen -o _build/native-examples/single-file.so
 	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-examples/single-file.so\")" -e "(if (= (answer 5) 26) ok (error \"native single-file example failed\"))"
 	./$(exe) compile examples/native/binding.shen -o _build/native-examples/compatible.so
@@ -302,12 +305,12 @@ test-native-examples: $(exe) $(runtime_artifacts)
 	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-examples/sealed.so\")" -e "(load \"examples/native/binding-update.shen\")" -e "(if (= (call-helper 1) 2) ok (error \"native sealed example failed\"))"
 	./$(exe) compile examples/native/package-effects.shen -o _build/native-examples/package-effects.so
 	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-examples/package-effects.so\")" -e "(if (= (effect-events) [\"inside-before-definition\" \"after-definition\"]) ok (error \"native package effects example failed\"))"
-	./$(exe) compile-module _build/native-examples/modules/native-example.core.shenmod -o _build/native-examples/modules/native-example.core.so
-	./$(exe) compile-module _build/native-examples/modules/native-example.app.shenmod --module-dir _build/native-examples/modules -o _build/native-examples/modules/native-example.app.so
-	./$(exe) eval -q -e "(shen-scheme.load-module \"_build/native-examples/modules/native-example.app.shenmod\" \"_build/native-examples/modules\")" -e "(if (= (run-example 32) 42) ok (error \"native module graph example failed\"))" -e "(if (= (module-events) [42]) ok (error \"native module initializer example failed\"))"
-	./$(exe) build-module-app _build/native-examples/modules/native-example.app.shenmod --module-dir _build/native-examples/modules -o _build/native-examples/app.so
+	./$(exe) compile-module examples/native/modules/native-example.core.shenmod -o _build/native-examples/objects/native-example.core.so
+	./$(exe) compile-module examples/native/modules/native-example.app.shenmod --module-dir examples/native/modules -o _build/native-examples/objects/native-example.app.so
+	./$(exe) eval -q -e "(shen-scheme.load-module \"examples/native/modules/native-example.app.shenmod\" \"examples/native/modules\" \"_build/native-examples/objects\")" -e "(if (= (run-example 32) 42) ok (error \"native module graph example failed\"))" -e "(if (= (module-events) [42]) ok (error \"native module initializer example failed\"))"
+	./$(exe) build-module-app examples/native/modules/native-example.app.shenmod --module-dir examples/native/modules -o _build/native-examples/app.so
 	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-examples/app.so\")" -e "(if (= (run-example 32) 42) ok (error \"native module app example failed\"))" -e "(if (= (module-events) [42]) ok (error \"native module app initializer example failed\"))"
-	./$(exe) build-module-app _build/native-examples/modules/native-example.app.shenmod --module-dir _build/native-examples/modules -o _build/native-examples/app-wpo.so --wpo
+	./$(exe) build-module-app examples/native/modules/native-example.app.shenmod --module-dir examples/native/modules -o _build/native-examples/app-wpo.so --wpo
 	./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-examples/app-wpo.so\")" -e "(if (= (run-example 32) 42) ok (error \"native WPO module app example failed\"))"
 	SHEN_SCHEME_RUNTIME=petite ./$(exe) eval -q -e "(shen-scheme.load-compiled \"_build/native-examples/single-file.so\")" -e "(if (= (answer 5) 26) ok (error \"native full-to-Petite example failed\"))"
 

--- a/benchmarks/port/port-bench.whole-compatible.shenmod
+++ b/benchmarks/port/port-bench.whole-compatible.shenmod
@@ -1,11 +1,11 @@
 (shen.module
   (version 1)
   (name port.bench.whole-compatible)
-  (sources tc- "benchmarks/port-adapter.shen"
-           "benchmarks/port/data.shen"
-           "benchmarks/port/control-flow.shen"
-           "benchmarks/port/shen-compilation.shen"
-           "benchmarks/port/pattern-matching.shen"
-           "benchmarks/port/equality-check.shen")
+  (sources tc- "../port-adapter.shen"
+           "data.shen"
+           "control-flow.shen"
+           "shen-compilation.shen"
+           "pattern-matching.shen"
+           "equality-check.shen")
   (extension shen/scheme
     (mode compatible)))

--- a/benchmarks/port/port-bench.whole-compatible.shenmod
+++ b/benchmarks/port/port-bench.whole-compatible.shenmod
@@ -1,9 +1,11 @@
-(shen.aot.module
+(shen.module
+  (version 1)
   (name port.bench.whole-compatible)
-  (mode compatible)
-  (sources "benchmarks/port-adapter.shen"
+  (sources tc- "benchmarks/port-adapter.shen"
            "benchmarks/port/data.shen"
            "benchmarks/port/control-flow.shen"
            "benchmarks/port/shen-compilation.shen"
            "benchmarks/port/pattern-matching.shen"
-           "benchmarks/port/equality-check.shen"))
+           "benchmarks/port/equality-check.shen")
+  (extension shen/scheme
+    (mode compatible)))

--- a/benchmarks/port/port-bench.whole-sealed.shenmod
+++ b/benchmarks/port/port-bench.whole-sealed.shenmod
@@ -1,9 +1,11 @@
-(shen.aot.module
+(shen.module
+  (version 1)
   (name port.bench.whole-sealed)
-  (mode sealed)
-  (sources "benchmarks/port-adapter.shen"
+  (sources tc- "benchmarks/port-adapter.shen"
            "benchmarks/port/data.shen"
            "benchmarks/port/control-flow.shen"
            "benchmarks/port/shen-compilation.shen"
            "benchmarks/port/pattern-matching.shen"
-           "benchmarks/port/equality-check.shen"))
+           "benchmarks/port/equality-check.shen")
+  (extension shen/scheme
+    (mode sealed)))

--- a/benchmarks/port/port-bench.whole-sealed.shenmod
+++ b/benchmarks/port/port-bench.whole-sealed.shenmod
@@ -1,11 +1,11 @@
 (shen.module
   (version 1)
   (name port.bench.whole-sealed)
-  (sources tc- "benchmarks/port-adapter.shen"
-           "benchmarks/port/data.shen"
-           "benchmarks/port/control-flow.shen"
-           "benchmarks/port/shen-compilation.shen"
-           "benchmarks/port/pattern-matching.shen"
-           "benchmarks/port/equality-check.shen")
+  (sources tc- "../port-adapter.shen"
+           "data.shen"
+           "control-flow.shen"
+           "shen-compilation.shen"
+           "pattern-matching.shen"
+           "equality-check.shen")
   (extension shen/scheme
     (mode sealed)))

--- a/benchmarks/realistic/realistic.bench.analysis.shenmod
+++ b/benchmarks/realistic/realistic.bench.analysis.shenmod
@@ -1,7 +1,9 @@
-(shen.aot.module
+(shen.module
+  (version 1)
   (name realistic.bench.analysis)
-  (mode sealed)
   (requires realistic.bench.core)
-  (exports realistic-bench.free-vars
-           realistic-bench.ast-size)
-  (sources "benchmarks/realistic/analysis.shen"))
+  (sources tc- "benchmarks/realistic/analysis.shen")
+  (extension shen/scheme
+    (mode sealed)
+    (exports realistic-bench.free-vars
+             realistic-bench.ast-size)))

--- a/benchmarks/realistic/realistic.bench.analysis.shenmod
+++ b/benchmarks/realistic/realistic.bench.analysis.shenmod
@@ -2,7 +2,7 @@
   (version 1)
   (name realistic.bench.analysis)
   (requires realistic.bench.core)
-  (sources tc- "benchmarks/realistic/analysis.shen")
+  (sources tc- "analysis.shen")
   (extension shen/scheme
     (mode sealed)
     (exports realistic-bench.free-vars

--- a/benchmarks/realistic/realistic.bench.compile.shenmod
+++ b/benchmarks/realistic/realistic.bench.compile.shenmod
@@ -1,5 +1,7 @@
-(shen.aot.module
+(shen.module
+  (version 1)
   (name realistic.bench.compile)
-  (mode sealed)
-  (exports realistic-bench.compile-ast)
-  (sources "benchmarks/realistic/compile.shen"))
+  (sources tc- "benchmarks/realistic/compile.shen")
+  (extension shen/scheme
+    (mode sealed)
+    (exports realistic-bench.compile-ast)))

--- a/benchmarks/realistic/realistic.bench.compile.shenmod
+++ b/benchmarks/realistic/realistic.bench.compile.shenmod
@@ -1,7 +1,7 @@
 (shen.module
   (version 1)
   (name realistic.bench.compile)
-  (sources tc- "benchmarks/realistic/compile.shen")
+  (sources tc- "compile.shen")
   (extension shen/scheme
     (mode sealed)
     (exports realistic-bench.compile-ast)))

--- a/benchmarks/realistic/realistic.bench.core.shenmod
+++ b/benchmarks/realistic/realistic.bench.core.shenmod
@@ -1,7 +1,7 @@
 (shen.module
   (version 1)
   (name realistic.bench.core)
-  (sources tc- "benchmarks/realistic/core.shen")
+  (sources tc- "core.shen")
   (extension shen/scheme
     (mode sealed)
     (exports realistic-bench.member?

--- a/benchmarks/realistic/realistic.bench.core.shenmod
+++ b/benchmarks/realistic/realistic.bench.core.shenmod
@@ -1,14 +1,16 @@
-(shen.aot.module
+(shen.module
+  (version 1)
   (name realistic.bench.core)
-  (mode sealed)
-  (exports realistic-bench.member?
-           realistic-bench.add-unique
-           realistic-bench.union-vars
-           realistic-bench.remove-var
-           realistic-bench.list-length
-           realistic-bench.env-lookup
-           realistic-bench.initial-env
-           realistic-bench.make-program
-           realistic-bench.make-block
-           realistic-bench.make-expr)
-  (sources "benchmarks/realistic/core.shen"))
+  (sources tc- "benchmarks/realistic/core.shen")
+  (extension shen/scheme
+    (mode sealed)
+    (exports realistic-bench.member?
+             realistic-bench.add-unique
+             realistic-bench.union-vars
+             realistic-bench.remove-var
+             realistic-bench.list-length
+             realistic-bench.env-lookup
+             realistic-bench.initial-env
+             realistic-bench.make-program
+             realistic-bench.make-block
+             realistic-bench.make-expr)))

--- a/benchmarks/realistic/realistic.bench.main.shenmod
+++ b/benchmarks/realistic/realistic.bench.main.shenmod
@@ -6,7 +6,7 @@
             realistic.bench.optimize
             realistic.bench.compile
             realistic.bench.vm)
-  (sources tc- "benchmarks/realistic/main.shen")
+  (sources tc- "main.shen")
   (extension shen/scheme
     (mode sealed)
     (exports realistic-bench.pipeline

--- a/benchmarks/realistic/realistic.bench.main.shenmod
+++ b/benchmarks/realistic/realistic.bench.main.shenmod
@@ -1,15 +1,17 @@
-(shen.aot.module
+(shen.module
+  (version 1)
   (name realistic.bench.main)
-  (mode sealed)
   (requires realistic.bench.core
             realistic.bench.analysis
             realistic.bench.optimize
             realistic.bench.compile
             realistic.bench.vm)
-  (exports realistic-bench.pipeline
-           realistic-bench.pipeline-loop
-           realistic-bench.run-pipeline
-           realistic-bench.prepare-code
-           realistic-bench.bytecode-loop
-           realistic-bench.run-bytecode)
-  (sources "benchmarks/realistic/main.shen"))
+  (sources tc- "benchmarks/realistic/main.shen")
+  (extension shen/scheme
+    (mode sealed)
+    (exports realistic-bench.pipeline
+             realistic-bench.pipeline-loop
+             realistic-bench.run-pipeline
+             realistic-bench.prepare-code
+             realistic-bench.bytecode-loop
+             realistic-bench.run-bytecode)))

--- a/benchmarks/realistic/realistic.bench.optimize.shenmod
+++ b/benchmarks/realistic/realistic.bench.optimize.shenmod
@@ -1,12 +1,14 @@
-(shen.aot.module
+(shen.module
+  (version 1)
   (name realistic.bench.optimize)
-  (mode sealed)
   (requires realistic.bench.core
             realistic.bench.analysis)
-  (exports realistic-bench.normalise
-           realistic-bench.simplify
-           realistic-bench.simplify-add
-           realistic-bench.simplify-mul
-           realistic-bench.simplify-let
-           realistic-bench.optimise-ast)
-  (sources "benchmarks/realistic/optimize.shen"))
+  (sources tc- "benchmarks/realistic/optimize.shen")
+  (extension shen/scheme
+    (mode sealed)
+    (exports realistic-bench.normalise
+             realistic-bench.simplify
+             realistic-bench.simplify-add
+             realistic-bench.simplify-mul
+             realistic-bench.simplify-let
+             realistic-bench.optimise-ast)))

--- a/benchmarks/realistic/realistic.bench.optimize.shenmod
+++ b/benchmarks/realistic/realistic.bench.optimize.shenmod
@@ -3,7 +3,7 @@
   (name realistic.bench.optimize)
   (requires realistic.bench.core
             realistic.bench.analysis)
-  (sources tc- "benchmarks/realistic/optimize.shen")
+  (sources tc- "optimize.shen")
   (extension shen/scheme
     (mode sealed)
     (exports realistic-bench.normalise

--- a/benchmarks/realistic/realistic.bench.vm.shenmod
+++ b/benchmarks/realistic/realistic.bench.vm.shenmod
@@ -2,7 +2,7 @@
   (version 1)
   (name realistic.bench.vm)
   (requires realistic.bench.core)
-  (sources tc- "benchmarks/realistic/vm.shen")
+  (sources tc- "vm.shen")
   (extension shen/scheme
     (mode sealed)
     (exports realistic-bench.run-code

--- a/benchmarks/realistic/realistic.bench.vm.shenmod
+++ b/benchmarks/realistic/realistic.bench.vm.shenmod
@@ -1,17 +1,19 @@
-(shen.aot.module
+(shen.module
+  (version 1)
   (name realistic.bench.vm)
-  (mode sealed)
   (requires realistic.bench.core)
-  (exports realistic-bench.run-code
-           realistic-bench.push-const
-           realistic-bench.push-load
-           realistic-bench.add-values
-           realistic-bench.sub-values
-           realistic-bench.mul-values
-           realistic-bench.apply-add
-           realistic-bench.apply-sub
-           realistic-bench.apply-mul
-           realistic-bench.push-binding
-           realistic-bench.drop-binding
-           realistic-bench.exec)
-  (sources "benchmarks/realistic/vm.shen"))
+  (sources tc- "benchmarks/realistic/vm.shen")
+  (extension shen/scheme
+    (mode sealed)
+    (exports realistic-bench.run-code
+             realistic-bench.push-const
+             realistic-bench.push-load
+             realistic-bench.add-values
+             realistic-bench.sub-values
+             realistic-bench.mul-values
+             realistic-bench.apply-add
+             realistic-bench.apply-sub
+             realistic-bench.apply-mul
+             realistic-bench.push-binding
+             realistic-bench.drop-binding
+             realistic-bench.exec)))

--- a/benchmarks/realistic/realistic.bench.whole-compatible.shenmod
+++ b/benchmarks/realistic/realistic.bench.whole-compatible.shenmod
@@ -1,9 +1,11 @@
-(shen.aot.module
+(shen.module
+  (version 1)
   (name realistic.bench.whole-compatible)
-  (mode compatible)
-  (sources "benchmarks/realistic/core.shen"
+  (sources tc- "benchmarks/realistic/core.shen"
            "benchmarks/realistic/analysis.shen"
            "benchmarks/realistic/optimize.shen"
            "benchmarks/realistic/compile.shen"
            "benchmarks/realistic/vm.shen"
-           "benchmarks/realistic/main.shen"))
+           "benchmarks/realistic/main.shen")
+  (extension shen/scheme
+    (mode compatible)))

--- a/benchmarks/realistic/realistic.bench.whole-compatible.shenmod
+++ b/benchmarks/realistic/realistic.bench.whole-compatible.shenmod
@@ -1,11 +1,11 @@
 (shen.module
   (version 1)
   (name realistic.bench.whole-compatible)
-  (sources tc- "benchmarks/realistic/core.shen"
-           "benchmarks/realistic/analysis.shen"
-           "benchmarks/realistic/optimize.shen"
-           "benchmarks/realistic/compile.shen"
-           "benchmarks/realistic/vm.shen"
-           "benchmarks/realistic/main.shen")
+  (sources tc- "core.shen"
+           "analysis.shen"
+           "optimize.shen"
+           "compile.shen"
+           "vm.shen"
+           "main.shen")
   (extension shen/scheme
     (mode compatible)))

--- a/benchmarks/realistic/realistic.bench.whole-sealed.shenmod
+++ b/benchmarks/realistic/realistic.bench.whole-sealed.shenmod
@@ -1,9 +1,11 @@
-(shen.aot.module
+(shen.module
+  (version 1)
   (name realistic.bench.whole-sealed)
-  (mode sealed)
-  (sources "benchmarks/realistic/core.shen"
+  (sources tc- "benchmarks/realistic/core.shen"
            "benchmarks/realistic/analysis.shen"
            "benchmarks/realistic/optimize.shen"
            "benchmarks/realistic/compile.shen"
            "benchmarks/realistic/vm.shen"
-           "benchmarks/realistic/main.shen"))
+           "benchmarks/realistic/main.shen")
+  (extension shen/scheme
+    (mode sealed)))

--- a/benchmarks/realistic/realistic.bench.whole-sealed.shenmod
+++ b/benchmarks/realistic/realistic.bench.whole-sealed.shenmod
@@ -1,11 +1,11 @@
 (shen.module
   (version 1)
   (name realistic.bench.whole-sealed)
-  (sources tc- "benchmarks/realistic/core.shen"
-           "benchmarks/realistic/analysis.shen"
-           "benchmarks/realistic/optimize.shen"
-           "benchmarks/realistic/compile.shen"
-           "benchmarks/realistic/vm.shen"
-           "benchmarks/realistic/main.shen")
+  (sources tc- "core.shen"
+           "analysis.shen"
+           "optimize.shen"
+           "compile.shen"
+           "vm.shen"
+           "main.shen")
   (extension shen/scheme
     (mode sealed)))

--- a/docs/native-compilation.md
+++ b/docs/native-compilation.md
@@ -194,9 +194,17 @@ The `shen/scheme` extension has these fields:
 | `profile` | `release` | `release`, `debug`, `wpo`, or `unsafe` for standalone compilation |
 
 Relative source paths are resolved from the descriptor's directory. Absolute
-paths are left unchanged. The listed files are read in order and analyzed as
-one unit, so a definition may call another definition appearing in a later
-source. If a function is defined repeatedly, the final definition is compiled.
+paths are left unchanged. The listed files are compiled in order, so macros,
+declarations, datatypes, synonyms, and arities established by one source are
+available to the sources that follow it. Put a definition before sources that
+need its arity. If a function is defined repeatedly, the final definition is
+compiled.
+
+`tc+` and `tc-` are stateful markers within `sources`; each applies until the
+next marker. A `tc+` source is typechecked and its inline function signatures
+are included in compile-time metadata. A `tc-` source is compiled without
+typechecking and does not contribute inline signatures. Explicit `declare`
+forms remain effective in either mode.
 
 An explicit Shen/Scheme export list requires `sealed` mode for a standalone module.
 `compatible` standalone modules use `infer-all`, because dynamically resolved

--- a/docs/native-compilation.md
+++ b/docs/native-compilation.md
@@ -142,13 +142,14 @@ They solve different problems:
 - A Shen `package` form is part of the Shen language. It qualifies internal
   symbols and records the package's external and internal names. Native
   compilation supports package forms and preserves package registration.
-- A `.shenmod` file is build metadata. It names a compilation unit, lists its
-  source files and dependencies, and controls native exports and metadata. It
-  does not qualify Shen symbols and does not replace `package`.
+- A `.shenmod` file is portable module metadata. Its core names a compilation
+  unit and lists source files, feature requirements, and module dependencies.
+  Namespaced extensions carry settings used by a particular implementation.
+  It does not qualify Shen symbols and does not replace `package`.
 
-A source listed by a module can contain one or more packages. The descriptor's
-`exports` are the native boundary; package externals are the Shen namespace
-boundary. Keep both when both concepts are useful.
+A source listed by a module can contain one or more packages. The Shen/Scheme
+extension's `exports` are the native boundary; package externals are the Shen
+namespace boundary. Keep both when both concepts are useful.
 
 See [package-effects.shen](../examples/native/package-effects.shen) for a
 package whose effects are restored when its compiled object is loaded.
@@ -158,22 +159,36 @@ package whose effects are restored when its compiled object is loaded.
 A declaration is one raw Shen form. It is read without macro expansion:
 
 ```shen
-(shen.aot.module
+(shen.module
+  (version 1)
   (name my.math)
-  (mode sealed)
   (requires my.core)
-  (exports my.add my.sum)
-  (metadata runtime compiletime source-kl)
-  (profile release)
-  (sources "src/math.shen"))
+  (requires-features shen/scheme)
+  (sources tc- "src/math.shen")
+  (extension shen/scheme
+    (mode sealed)
+    (exports my.add my.sum)
+    (metadata runtime compiletime source-kl)
+    (profile release)))
 ```
 
-| Field | Required/default | Meaning |
+Portable fields are order-independent. `extension` may occur once per
+extension name; Shen/Scheme preserves extensions it does not recognize.
+
+| Core field | Required/default | Meaning |
 | --- | --- | --- |
+| `version` | Required, exactly `1` | Portable descriptor format version |
 | `name` | Required | Symbolic module name used by `requires` and file lookup |
-| `sources` | Required, one or more paths | Source files forming one compilation unit |
-| `mode` | `compatible` | `compatible` or `sealed` for standalone `compile-module` |
 | `requires` | Empty | Symbolic module dependencies |
+| `requires-features` | Empty | Port or library features needed by the module |
+| `sources` | Required, one or more paths | Ordered source paths, each following a `tc+` or `tc-` marker |
+| `extension` | Optional, repeatable | Namespaced implementation settings |
+
+The `shen/scheme` extension has these fields:
+
+| Extension field | Default | Meaning |
+| --- | --- | --- |
+| `mode` | `compatible` | `compatible` or `sealed` for standalone `compile-module` |
 | `exports` | `infer-all` | Exported function names, or every definition |
 | `metadata` | `runtime compiletime` | Any of `runtime`, `compiletime`, and `source-kl` |
 | `profile` | `release` | `release`, `debug`, `wpo`, or `unsafe` for standalone compilation |
@@ -183,7 +198,7 @@ descriptor's directory. The listed files are read in order and analyzed as one
 unit, so a definition may call another definition appearing in a later source.
 If a function is defined repeatedly, the final definition is compiled.
 
-An explicit export list requires `sealed` mode for a standalone module.
+An explicit Shen/Scheme export list requires `sealed` mode for a standalone module.
 `compatible` standalone modules use `infer-all`, because dynamically resolved
 top-level calls do not provide a private native boundary.
 

--- a/docs/native-compilation.md
+++ b/docs/native-compilation.md
@@ -195,11 +195,11 @@ The `shen/scheme` extension has these fields:
 | `profile` | `release` | `release`, `debug`, `wpo`, or `unsafe` for standalone compilation |
 
 Source paths must be relative and are resolved from the descriptor's
-directory. The listed files are compiled in order, so macros,
-declarations, datatypes, synonyms, and arities established by one source are
-available to the sources that follow it. Put a definition before sources that
-need its arity. If a function is defined repeatedly, the final definition is
-compiled.
+directory. The listed files are compiled in order, so macros, declarations,
+datatypes, synonyms, registered pattern handlers, and arities established by
+one source are available to the sources that follow it. Put a definition
+before sources that need its arity. If a function is defined repeatedly, the
+final definition is compiled.
 
 `tc+` and `tc-` are stateful markers within `sources`; each applies until the
 next marker. A `tc+` source is typechecked and its inline function signatures
@@ -256,6 +256,14 @@ available while compiling dependants.
 dependants and returns a list of the loaded module names. Cycles and missing
 declarations or objects are errors. If standalone direct requirements export
 the same function, the later direct requirement takes precedence.
+
+Top-level programmable-pattern-matching `register-handler` and
+`unregister-handler` calls take effect at the end of their source file. A
+handler is therefore available to later source files and dependent modules,
+but not to definitions in the file that registers it. Put custom-pattern
+consumers in a following source. Native objects replay these operations as
+compile-time metadata and as runtime initializers; a sealed handler may remain
+private because its compiled closure is carried by the registration operation.
 
 ## Application objects
 
@@ -325,7 +333,8 @@ Descriptor metadata controls what is restored in the loading Shen image:
 
 - `runtime` records exported arities and installs the needed exported
   top-level bindings for sealed modules and module apps.
-- `compiletime` replays declarations, macros, datatypes, and synonyms.
+- `compiletime` replays declarations, macros, datatypes, synonyms, and
+  programmable-pattern handler changes.
 - `source-kl` records KLambda for `ps` and user-definition introspection.
 
 Package external/internal registration is preserved independently of that
@@ -573,6 +582,9 @@ The primitive workloads are vendored unchanged from `shen-sources`; see their
 - A dependency macro must be self-contained or use helpers already present in
   the compiler. Ordinary helpers defined only in dependency source are not
   installed during dependency analysis.
+- A pattern handler used during native compilation must likewise be
+  self-contained or use helpers already present in the compiler. The handler
+  itself may remain private to a sealed module.
 - Macro transformer names share the live compiler namespace and must not
   collide with existing bindings.
 - Unusual compile-time rewrites that depend on another module's `declare`

--- a/docs/native-compilation.md
+++ b/docs/native-compilation.md
@@ -37,7 +37,8 @@ shen-scheme compile SOURCE -o OBJECT
 shen-scheme load-compiled OBJECT
 shen-scheme compile-module DECLARATION -o OBJECT
   [--emit-scheme SCHEME] [--module-dir DIR]
-shen-scheme load-module DECLARATION --module-dir DIR
+shen-scheme load-module DECLARATION
+  --module-dir MODULE_DIR --object-dir OBJECT_DIR
 shen-scheme build-app MAIN [--module SOURCE ...] -o OBJECT
   [--wpo] [--profile release|debug|wpo|unsafe]
 shen-scheme build-module-app DECLARATION --module-dir DIR -o OBJECT
@@ -217,31 +218,31 @@ The example descriptors are:
 - [native-example.core.shenmod](../examples/native/modules/native-example.core.shenmod)
 - [native-example.app.shenmod](../examples/native/modules/native-example.app.shenmod)
 
-Compile each object under the name used by the resolver, then load the root:
+Keep declarations beside their sources, compile each object under the name used
+by the resolver, then load the root with separate module and object roots:
 
 ```sh
-mkdir -p _build/native-examples/modules
-cp examples/native/modules/native-example.* _build/native-examples/modules/
+mkdir -p _build/native-examples/objects
 ./_build/bin/shen-scheme compile-module \
-  _build/native-examples/modules/native-example.core.shenmod \
-  -o _build/native-examples/modules/native-example.core.so
+  examples/native/modules/native-example.core.shenmod \
+  -o _build/native-examples/objects/native-example.core.so
 ./_build/bin/shen-scheme compile-module \
-  _build/native-examples/modules/native-example.app.shenmod \
-  --module-dir _build/native-examples/modules \
-  -o _build/native-examples/modules/native-example.app.so
+  examples/native/modules/native-example.app.shenmod \
+  --module-dir examples/native/modules \
+  -o _build/native-examples/objects/native-example.app.so
 ./_build/bin/shen-scheme eval \
-  -e '(shen-scheme.load-module "_build/native-examples/modules/native-example.app.shenmod" "_build/native-examples/modules")' \
+  -e '(shen-scheme.load-module "examples/native/modules/native-example.app.shenmod" "examples/native/modules" "_build/native-examples/objects")' \
   -e '(run-example 32)' \
   -e '(module-events)'
 ```
 
 The last two expressions return `42` and `[42]`.
 
-For a required module named `my.core`, `--module-dir DIR` resolves:
+For a required module named `my.core`, the two roots resolve:
 
 ```text
-DIR/my.core.shenmod
-DIR/my.core.so
+MODULE_DIR/my.core.shenmod
+OBJECT_DIR/my.core.so
 ```
 
 `compile-module` analyzes dependency declarations and source files in
@@ -450,12 +451,13 @@ Each returns `O`.
 (shen-scheme.compile-module/emit F O Scm)
 (shen-scheme.compile-module/emit/in-dir F O Scm Dir)
 (shen-scheme.load-compiled O)
-(shen-scheme.load-module F Dir)
+(shen-scheme.load-module F ModuleDir ObjectDir)
 ```
 
 The compilation functions and `load-compiled` return `O`. `load-module`
 returns the loaded module-name list; dependencies are initialized before
-dependants.
+dependants. `ModuleDir` contains declarations and `ObjectDir` contains compiled
+module objects.
 
 ### Applications
 

--- a/docs/native-compilation.md
+++ b/docs/native-compilation.md
@@ -193,8 +193,8 @@ The `shen/scheme` extension has these fields:
 | `metadata` | `runtime compiletime` | Any of `runtime`, `compiletime`, and `source-kl` |
 | `profile` | `release` | `release`, `debug`, `wpo`, or `unsafe` for standalone compilation |
 
-Relative source paths are resolved from the descriptor's directory. Absolute
-paths are left unchanged. The listed files are compiled in order, so macros,
+Source paths must be relative and are resolved from the descriptor's
+directory. The listed files are compiled in order, so macros,
 declarations, datatypes, synonyms, and arities established by one source are
 available to the sources that follow it. Put a definition before sources that
 need its arity. If a function is defined repeatedly, the final definition is

--- a/docs/native-compilation.md
+++ b/docs/native-compilation.md
@@ -193,10 +193,10 @@ The `shen/scheme` extension has these fields:
 | `metadata` | `runtime compiletime` | Any of `runtime`, `compiletime`, and `source-kl` |
 | `profile` | `release` | `release`, `debug`, `wpo`, or `unsafe` for standalone compilation |
 
-Source paths are resolved from the process working directory, not from the
-descriptor's directory. The listed files are read in order and analyzed as one
-unit, so a definition may call another definition appearing in a later source.
-If a function is defined repeatedly, the final definition is compiled.
+Relative source paths are resolved from the descriptor's directory. Absolute
+paths are left unchanged. The listed files are read in order and analyzed as
+one unit, so a definition may call another definition appearing in a later
+source. If a function is defined repeatedly, the final definition is compiled.
 
 An explicit Shen/Scheme export list requires `sealed` mode for a standalone module.
 `compatible` standalone modules use `infer-all`, because dynamically resolved
@@ -213,7 +213,7 @@ Compile each object under the name used by the resolver, then load the root:
 
 ```sh
 mkdir -p _build/native-examples/modules
-cp examples/native/modules/*.shenmod _build/native-examples/modules/
+cp examples/native/modules/native-example.* _build/native-examples/modules/
 ./_build/bin/shen-scheme compile-module \
   _build/native-examples/modules/native-example.core.shenmod \
   -o _build/native-examples/modules/native-example.core.so

--- a/examples/native/README.md
+++ b/examples/native/README.md
@@ -78,12 +78,13 @@ instead describes native compilation, dependencies, exports, and metadata. The
 example modules use both mechanisms.
 
 `load-module` resolves both declarations and compiled objects by module name in
-one module directory. Copy the declarations to the build directory so generated
-objects stay outside the source tree:
+one module directory. Relative sources are resolved from each declaration's
+directory, so copy each example module's source and declaration together while
+keeping generated objects outside the source tree:
 
 ```sh
 mkdir -p _build/native-examples/modules
-cp examples/native/modules/*.shenmod _build/native-examples/modules/
+cp examples/native/modules/native-example.* _build/native-examples/modules/
 
 ./_build/bin/shen-scheme compile-module \
   _build/native-examples/modules/native-example.core.shenmod \

--- a/examples/native/README.md
+++ b/examples/native/README.md
@@ -77,24 +77,23 @@ A Shen package controls source-level qualification. A `.shenmod` declaration
 instead describes native compilation, dependencies, exports, and metadata. The
 example modules use both mechanisms.
 
-`load-module` resolves both declarations and compiled objects by module name in
-one module directory. Relative sources are resolved from each declaration's
-directory, so copy each example module's source and declaration together while
-keeping generated objects outside the source tree:
+`load-module` resolves declarations and compiled objects by module name from
+separate roots. Relative sources are resolved from each declaration's
+directory, so declarations stay beside their sources while generated objects
+go under `_build`:
 
 ```sh
-mkdir -p _build/native-examples/modules
-cp examples/native/modules/native-example.* _build/native-examples/modules/
+mkdir -p _build/native-examples/objects
 
 ./_build/bin/shen-scheme compile-module \
-  _build/native-examples/modules/native-example.core.shenmod \
-  -o _build/native-examples/modules/native-example.core.so
+  examples/native/modules/native-example.core.shenmod \
+  -o _build/native-examples/objects/native-example.core.so
 ./_build/bin/shen-scheme compile-module \
-  _build/native-examples/modules/native-example.app.shenmod \
-  --module-dir _build/native-examples/modules \
-  -o _build/native-examples/modules/native-example.app.so
+  examples/native/modules/native-example.app.shenmod \
+  --module-dir examples/native/modules \
+  -o _build/native-examples/objects/native-example.app.so
 ./_build/bin/shen-scheme eval \
-  -e '(shen-scheme.load-module "_build/native-examples/modules/native-example.app.shenmod" "_build/native-examples/modules")' \
+  -e '(shen-scheme.load-module "examples/native/modules/native-example.app.shenmod" "examples/native/modules" "_build/native-examples/objects")' \
   -e '(run-example 32)' \
   -e '(module-events)'
 ```
@@ -109,8 +108,8 @@ cross-module calls.
 
 ```sh
 ./_build/bin/shen-scheme build-module-app \
-  _build/native-examples/modules/native-example.app.shenmod \
-  --module-dir _build/native-examples/modules \
+  examples/native/modules/native-example.app.shenmod \
+  --module-dir examples/native/modules \
   -o _build/native-examples/app.so
 ./_build/bin/shen-scheme eval \
   -e '(shen-scheme.load-compiled "_build/native-examples/app.so")' \

--- a/examples/native/modules/native-example.app.shenmod
+++ b/examples/native/modules/native-example.app.shenmod
@@ -2,7 +2,7 @@
   (version 1)
   (name native-example.app)
   (requires native-example.core)
-  (sources tc- "examples/native/modules/native-example.app.shen")
+  (sources tc- "native-example.app.shen")
   (extension shen/scheme
     (mode sealed)
     (exports run-example module-events)

--- a/examples/native/modules/native-example.app.shenmod
+++ b/examples/native/modules/native-example.app.shenmod
@@ -1,7 +1,9 @@
-(shen.aot.module
+(shen.module
+  (version 1)
   (name native-example.app)
-  (mode sealed)
   (requires native-example.core)
-  (exports run-example module-events)
-  (metadata runtime compiletime)
-  (sources "examples/native/modules/native-example.app.shen"))
+  (sources tc- "examples/native/modules/native-example.app.shen")
+  (extension shen/scheme
+    (mode sealed)
+    (exports run-example module-events)
+    (metadata runtime compiletime)))

--- a/examples/native/modules/native-example.core.shenmod
+++ b/examples/native/modules/native-example.core.shenmod
@@ -1,6 +1,8 @@
-(shen.aot.module
+(shen.module
+  (version 1)
   (name native-example.core)
-  (mode sealed)
-  (exports add-ten)
-  (metadata runtime compiletime)
-  (sources "examples/native/modules/native-example.core.shen"))
+  (sources tc- "examples/native/modules/native-example.core.shen")
+  (extension shen/scheme
+    (mode sealed)
+    (exports add-ten)
+    (metadata runtime compiletime)))

--- a/examples/native/modules/native-example.core.shenmod
+++ b/examples/native/modules/native-example.core.shenmod
@@ -1,7 +1,7 @@
 (shen.module
   (version 1)
   (name native-example.core)
-  (sources tc- "examples/native/modules/native-example.core.shen")
+  (sources tc- "native-example.core.shen")
   (extension shen/scheme
     (mode sealed)
     (exports add-ten)

--- a/scripts/build.shen
+++ b/scripts/build.shen
@@ -75,7 +75,7 @@
        "extension-features"
        "extension-launcher"
        \\"extension-factorise-defun"
-       \\"extension-programmable-pattern-matching"
+       "extension-programmable-pattern-matching"
        ])
 
 (set *shen-scheme-files*
@@ -200,7 +200,7 @@
   [shen.initialise]
   [shen.x.features.initialise [cons (intern "shen/scheme") []]]
   \\[shen.x.factorise-defun.initialise]
-  \\[shen.x.programmable-pattern-matching.initialise]
+  [shen.x.programmable-pattern-matching.initialise]
 ])
 
 (define store-init-code
@@ -418,7 +418,7 @@
 (include c#34;compiled/extension-features.scmc#34;)
 (include c#34;compiled/extension-launcher.scmc#34;)
 ;; (include c#34;compiled/extension-factorise-defun.scmc#34;)
-;; (include c#34;compiled/extension-programmable-pattern-matching.scmc#34;)
+(include c#34;compiled/extension-programmable-pattern-matching.scmc#34;)
 
 )
 "))

--- a/scripts/run-native-core-regression-tests.shen
+++ b/scripts/run-native-core-regression-tests.shen
@@ -3,10 +3,10 @@
 
 (define native-test.run-core-regressions
   -> (let Dir "_build/native-tests"
-          ForwardCaller "_build/native-tests/core-forward-caller.shen"
-          ForwardTarget "_build/native-tests/core-forward-target.shen"
-          ForwardCompatible "_build/native-tests/core-forward-compatible.shenmod"
-          ForwardSealed "_build/native-tests/core-forward-sealed.shenmod"
+          OrderedCaller "_build/native-tests/core-ordered-caller.shen"
+          OrderedTarget "_build/native-tests/core-ordered-target.shen"
+          OrderedCompatible "_build/native-tests/core-ordered-compatible.shenmod"
+          OrderedSealed "_build/native-tests/core-ordered-sealed.shenmod"
           Duplicate "_build/native-tests/core-duplicate.shen"
           DuplicateModule "_build/native-tests/core-duplicate.shenmod"
           ArityBase "_build/native-tests/core-arity-base.shen"
@@ -18,54 +18,54 @@
           Assert (/. L E A (native-test.assert-equal L E A))
        (do
          (native-test.write-file
-          ForwardCaller
-          "(define native-core-forward-call
-  X -> (native-core-forward-target X 2))
+          OrderedCaller
+          "(define native-core-ordered-call
+  X -> (native-core-ordered-target X 2))
 ")
          (native-test.write-file
-          ForwardTarget
-          "(define native-core-forward-target
+          OrderedTarget
+          "(define native-core-ordered-target
   X Y -> (+ X Y))
 ")
          (native-test.write-file
-          ForwardCompatible
+          OrderedCompatible
           (make-string "(shen.module
   (version 1)
-  (name native.test.core-forward-compatible)
+  (name native.test.core-ordered-compatible)
   (sources tc- ~S ~S)
   (extension shen/scheme
     (mode compatible)))
 "
-                       (native-test.basename ForwardCaller)
-                       (native-test.basename ForwardTarget)))
+                       (native-test.basename OrderedTarget)
+                       (native-test.basename OrderedCaller)))
          (native-test.write-file
-          ForwardSealed
+          OrderedSealed
           (make-string "(shen.module
   (version 1)
-  (name native.test.core-forward-sealed)
+  (name native.test.core-ordered-sealed)
   (sources tc- ~S ~S)
   (extension shen/scheme
     (mode sealed)
-    (exports native-core-forward-call)))
+    (exports native-core-ordered-call)))
 "
-                       (native-test.basename ForwardCaller)
-                       (native-test.basename ForwardTarget)))
+                       (native-test.basename OrderedTarget)
+                       (native-test.basename OrderedCaller)))
          (shen-scheme.compile-module
-          ForwardCompatible
-          "_build/native-tests/core-forward-compatible.so")
+          OrderedCompatible
+          "_build/native-tests/core-ordered-compatible.so")
          (shen-scheme.load-compiled
-          "_build/native-tests/core-forward-compatible.so")
-         (Assert "compatible source set sees later arity"
+          "_build/native-tests/core-ordered-compatible.so")
+         (Assert "compatible source set sees earlier arity"
                  42
-                 (eval [native-core-forward-call 40]))
+                 (eval [native-core-ordered-call 40]))
          (shen-scheme.compile-module
-          ForwardSealed
-          "_build/native-tests/core-forward-sealed.so")
+          OrderedSealed
+          "_build/native-tests/core-ordered-sealed.so")
          (shen-scheme.load-compiled
-          "_build/native-tests/core-forward-sealed.so")
-         (Assert "sealed source set sees later arity"
+          "_build/native-tests/core-ordered-sealed.so")
+         (Assert "sealed source set sees earlier arity"
                  42
-                 (eval [native-core-forward-call 40]))
+                 (eval [native-core-ordered-call 40]))
 
          (native-test.write-file
          Duplicate

--- a/scripts/run-native-core-regression-tests.shen
+++ b/scripts/run-native-core-regression-tests.shen
@@ -36,7 +36,8 @@
   (extension shen/scheme
     (mode compatible)))
 "
-                       ForwardCaller ForwardTarget))
+                       (native-test.basename ForwardCaller)
+                       (native-test.basename ForwardTarget)))
          (native-test.write-file
           ForwardSealed
           (make-string "(shen.module
@@ -47,7 +48,8 @@
     (mode sealed)
     (exports native-core-forward-call)))
 "
-                       ForwardCaller ForwardTarget))
+                       (native-test.basename ForwardCaller)
+                       (native-test.basename ForwardTarget)))
          (shen-scheme.compile-module
           ForwardCompatible
           "_build/native-tests/core-forward-compatible.so")
@@ -101,7 +103,7 @@
     (mode sealed)
     (exports native-core-duplicate-call)))
 "
-                       Duplicate))
+                       (native-test.basename Duplicate)))
          (shen-scheme.build-module-app
           DuplicateModule
           Dir

--- a/scripts/run-native-core-regression-tests.shen
+++ b/scripts/run-native-core-regression-tests.shen
@@ -29,19 +29,23 @@
 ")
          (native-test.write-file
           ForwardCompatible
-          (make-string "(shen.aot.module
+          (make-string "(shen.module
+  (version 1)
   (name native.test.core-forward-compatible)
-  (mode compatible)
-  (sources ~S ~S))
+  (sources tc- ~S ~S)
+  (extension shen/scheme
+    (mode compatible)))
 "
                        ForwardCaller ForwardTarget))
          (native-test.write-file
           ForwardSealed
-          (make-string "(shen.aot.module
+          (make-string "(shen.module
+  (version 1)
   (name native.test.core-forward-sealed)
-  (mode sealed)
-  (exports native-core-forward-call)
-  (sources ~S ~S))
+  (sources tc- ~S ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-core-forward-call)))
 "
                        ForwardCaller ForwardTarget))
          (shen-scheme.compile-module
@@ -89,11 +93,13 @@
                                 (value shen.*sigf*)))))
          (native-test.write-file
           DuplicateModule
-          (make-string "(shen.aot.module
+          (make-string "(shen.module
+  (version 1)
   (name native.test.core-duplicate)
-  (mode sealed)
-  (exports native-core-duplicate-call)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-core-duplicate-call)))
 "
                        Duplicate))
          (shen-scheme.build-module-app

--- a/scripts/run-native-module-regression-tests.shen
+++ b/scripts/run-native-module-regression-tests.shen
@@ -43,31 +43,37 @@
 ")
          (native-test.write-file
           BDeclaration
-          (make-string "(shen.aot.module
+          (make-string "(shen.module
+  (version 1)
   (name native.test.precedence-b)
-  (mode sealed)
-  (exports native-module-regression-shared)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-regression-shared)))
 "
                        BSource))
          (native-test.write-file
           ADeclaration
-          (make-string "(shen.aot.module
+          (make-string "(shen.module
+  (version 1)
   (name native.test.precedence-a)
-  (mode sealed)
   (requires native.test.precedence-b)
-  (exports native-module-regression-shared)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-regression-shared)))
 "
                        ASource))
          (native-test.write-file
           MainDeclaration
-          (make-string "(shen.aot.module
+          (make-string "(shen.module
+  (version 1)
   (name native.test.precedence-main)
-  (mode sealed)
   (requires native.test.precedence-a native.test.precedence-b)
-  (exports native-module-regression-main)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-regression-main)))
 "
                        MainSource))
          (native-test.delete-file-if-exists BObject)

--- a/scripts/run-native-module-regression-tests.shen
+++ b/scripts/run-native-module-regression-tests.shen
@@ -3,15 +3,19 @@
 
 (define native-test.run-module-dependency-regressions
   -> (let Dir "_build/native-tests"
+          ObjectDir "_build/native-tests/module-regression-objects"
           BSource "_build/native-tests/module-precedence-b.shen"
           ASource "_build/native-tests/module-precedence-a.shen"
           MainSource "_build/native-tests/module-precedence-main.shen"
           BDeclaration "_build/native-tests/native.test.precedence-b.shenmod"
           ADeclaration "_build/native-tests/native.test.precedence-a.shenmod"
           MainDeclaration "_build/native-tests/native.test.precedence-main.shenmod"
-          BObject "_build/native-tests/native.test.precedence-b.so"
-          AObject "_build/native-tests/native.test.precedence-a.so"
-          MainObject "_build/native-tests/native.test.precedence-main.so"
+          BObject
+          "_build/native-tests/module-regression-objects/native.test.precedence-b.so"
+          AObject
+          "_build/native-tests/module-regression-objects/native.test.precedence-a.so"
+          MainObject
+          "_build/native-tests/module-regression-objects/native.test.precedence-main.so"
           AppObject "_build/native-tests/module-precedence-app.so"
           Assert (/. Label Expected Actual
                     (native-test.assert-equal Label Expected Actual))
@@ -123,7 +127,7 @@
                      0
                      (value *native-module-regression-effects*))
              (set *native-module-regression-effects* 0)
-             (shen-scheme.load-module MainDeclaration Dir)
+             (shen-scheme.load-module MainDeclaration Dir ObjectDir)
              (Assert "module load does not repeat transitive initializer"
                      1
                      (value *native-module-regression-effects*))

--- a/scripts/run-native-module-regression-tests.shen
+++ b/scripts/run-native-module-regression-tests.shen
@@ -51,7 +51,7 @@
     (mode sealed)
     (exports native-module-regression-shared)))
 "
-                       BSource))
+                       (native-test.basename BSource)))
          (native-test.write-file
           ADeclaration
           (make-string "(shen.module
@@ -63,7 +63,7 @@
     (mode sealed)
     (exports native-module-regression-shared)))
 "
-                       ASource))
+                       (native-test.basename ASource)))
          (native-test.write-file
           MainDeclaration
           (make-string "(shen.module
@@ -75,7 +75,7 @@
     (mode sealed)
     (exports native-module-regression-main)))
 "
-                       MainSource))
+                       (native-test.basename MainSource)))
          (native-test.delete-file-if-exists BObject)
          (native-test.delete-file-if-exists AObject)
          (native-test.delete-file-if-exists MainObject)

--- a/scripts/run-native-ppm-tests.shen
+++ b/scripts/run-native-ppm-tests.shen
@@ -1,0 +1,353 @@
+\* Copyright (c) 2012-2021 Bruno Deferrari.  All rights reserved.    *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+(define native-test.ppm-handler-source
+  -> "(define @native-test-ppm-two
+  A B -> (@p A B))
+
+(package null []
+
+(define native-test-ppm-handler
+  Self AddTest Bind [@native-test-ppm-two A B]
+  -> (do (AddTest [tuple? Self])
+         (Bind A [fst Self])
+         (Bind B [snd Self]))
+  _ _ _ _ -> (fail))
+
+(shen.x.programmable-pattern-matching.register-handler
+ native-test-ppm-handler))
+")
+
+(define native-test.ppm-later-source
+  -> "(define native-test-ppm-later
+  (@native-test-ppm-two A B) -> [A B]
+  _ -> no)
+")
+
+(define native-test.ppm-macro-source
+  -> "(defmacro native-test-ppm-ordered-macro
+  (@native-test-ppm-two A B) -> [quote [A B]])
+")
+
+(define native-test.ppm-required-source
+  -> "(define native-test-ppm-required
+  (@native-test-ppm-two A B) -> [A B]
+  _ -> no)
+")
+
+(define native-test.ppm-same-file-source
+  -> (@s (native-test.ppm-handler-source)
+         "
+(define native-test-ppm-same-file
+  (@native-test-ppm-two A B) -> [A B]
+  _ -> no)
+"))
+
+(define native-test.ppm-invalid-source
+  -> "(define native-test-ppm-valid-before-error
+  (@native-test-ppm-two A B) -> [A B]
+  _ -> no)
+
+(define native-test-ppm-invalid
+  (@native-test-ppm-unknown X) -> X
+  _ -> no)
+")
+
+(define native-test.ppm-unregister-source
+  -> "(shen.x.programmable-pattern-matching.unregister-handler
+ native-test-ppm-handler)
+
+(define native-test-ppm-before-unregister
+  (@native-test-ppm-two A B) -> [A B]
+  _ -> no)
+")
+
+(define native-test.ppm-fresh-source
+  F -> (make-string "(define ~A
+  (@native-test-ppm-two A B) -> [A B]
+  _ -> no)
+" F))
+
+(define native-test.ppm-shadow-source
+  -> "(define native-test-ppm-later
+  X -> stale)
+
+(define native-test-ppm-required
+  X -> stale)
+")
+
+(define native-test.ppm-declaration
+  Name Sources Requires Exports Metadata
+  -> (make-string "(shen.module
+  (version 1)
+  (name ~A)
+  ~A
+  (sources tc- ~A)
+  (extension shen/scheme
+    (mode sealed)
+    (exports ~A)
+    (metadata ~A)))
+"
+                  Name
+                  (if (= Requires [])
+                      ""
+                      (make-string "(requires ~A)" Requires))
+                  (native-test.ppm-source-list Sources)
+                  Exports
+                  Metadata))
+
+(define native-test.ppm-source-list
+  [S] -> (make-string "~S" S)
+  [S | Ss] -> (make-string "~S ~A" S (native-test.ppm-source-list Ss)))
+
+(define native-test.ppm-handler-names
+  -> (value shen.x.programmable-pattern-matching.*pattern-handlers-reg*))
+
+(define native-test.ppm-handlers
+  -> (value shen.x.programmable-pattern-matching.*pattern-handlers*))
+
+(define native-test.ppm-call-private-handler
+  -> (native-test-ppm-handler
+      (@p 1 2)
+      (/. X true)
+      (/. X (/. Y bound))
+      [@native-test-ppm-two first second]))
+
+(define native-test.ppm-cleanup
+  -> (do (if (element? native-test-ppm-handler
+                       (native-test.ppm-handler-names))
+             (shen.x.programmable-pattern-matching.unregister-handler
+              native-test-ppm-handler)
+             skip)
+         (if (= [] (assoc native-test-ppm-ordered-macro (value *macros*)))
+             skip
+             (undefmacro native-test-ppm-ordered-macro))))
+
+(define native-test.run-native-ppm
+  -> (let Dir "_build/native-tests"
+          ObjectDir "_build/native-tests/module-objects"
+          HandlerSource "_build/native-tests/native-ppm-handler.shen"
+          LaterSource "_build/native-tests/native-ppm-later.shen"
+          MacroSource "_build/native-tests/native-ppm-macro.shen"
+          RequiredSource "_build/native-tests/native-ppm-required.shen"
+          SameFileSource "_build/native-tests/native-ppm-same-file.shen"
+          InvalidSource "_build/native-tests/native-ppm-invalid.shen"
+          UnregisterSource "_build/native-tests/native-ppm-unregister.shen"
+          CompiletimeFreshSource
+          "_build/native-tests/native-ppm-compiletime-fresh.shen"
+          RuntimeFreshSource
+          "_build/native-tests/native-ppm-runtime-fresh.shen"
+          ShadowSource "_build/native-tests/native-ppm-shadow.shen"
+          ProviderDeclaration
+          "_build/native-tests/native.test.ppm-provider.shenmod"
+          RuntimeDeclaration
+          "_build/native-tests/native.test.ppm-runtime.shenmod"
+          RootDeclaration
+          "_build/native-tests/native.test.ppm-root.shenmod"
+          SameFileDeclaration
+          "_build/native-tests/native.test.ppm-same-file.shenmod"
+          InvalidDeclaration
+          "_build/native-tests/native.test.ppm-invalid.shenmod"
+          UnregisterDeclaration
+          "_build/native-tests/native.test.ppm-unregister.shenmod"
+          ProviderObject
+          "_build/native-tests/module-objects/native.test.ppm-provider.so"
+          RuntimeObject
+          "_build/native-tests/module-objects/native.test.ppm-runtime.so"
+          RootObject
+          "_build/native-tests/module-objects/native.test.ppm-root.so"
+          SameFileObject
+          "_build/native-tests/module-objects/native.test.ppm-same-file.so"
+          InvalidObject
+          "_build/native-tests/module-objects/native.test.ppm-invalid.so"
+          UnregisterObject
+          "_build/native-tests/module-objects/native.test.ppm-unregister.so"
+          AppObject "_build/native-tests/native-ppm-app.so"
+          Assert (/. Label Expected Actual
+                    (native-test.assert-equal Label Expected Actual))
+       (do
+         (native-test.ppm-cleanup)
+         (let InitialNames (native-test.ppm-handler-names)
+              InitialHandlers (native-test.ppm-handlers)
+           (do
+             (native-test.write-file HandlerSource
+                                     (native-test.ppm-handler-source))
+             (native-test.write-file LaterSource
+                                     (native-test.ppm-later-source))
+             (native-test.write-file MacroSource
+                                     (native-test.ppm-macro-source))
+             (native-test.write-file RequiredSource
+                                     (native-test.ppm-required-source))
+             (native-test.write-file SameFileSource
+                                     (native-test.ppm-same-file-source))
+             (native-test.write-file InvalidSource
+                                     (native-test.ppm-invalid-source))
+             (native-test.write-file UnregisterSource
+                                     (native-test.ppm-unregister-source))
+             (native-test.write-file
+              CompiletimeFreshSource
+              (native-test.ppm-fresh-source
+               native-test-ppm-after-compiletime-load))
+             (native-test.write-file
+              RuntimeFreshSource
+              (native-test.ppm-fresh-source
+               native-test-ppm-after-runtime-load))
+             (native-test.write-file ShadowSource
+                                     (native-test.ppm-shadow-source))
+             (native-test.write-file
+              ProviderDeclaration
+              (native-test.ppm-declaration
+               native.test.ppm-provider
+               ["native-ppm-handler.shen" "native-ppm-later.shen"
+                "native-ppm-macro.shen"]
+               []
+               "@native-test-ppm-two native-test-ppm-later"
+               "runtime compiletime"))
+             (native-test.write-file
+              RuntimeDeclaration
+              (native-test.ppm-declaration
+               native.test.ppm-runtime
+               ["native-ppm-handler.shen" "native-ppm-later.shen"]
+               []
+               "@native-test-ppm-two native-test-ppm-later"
+               runtime))
+             (native-test.write-file
+              RootDeclaration
+              (native-test.ppm-declaration
+               native.test.ppm-root
+               ["native-ppm-required.shen"]
+               native.test.ppm-provider
+               native-test-ppm-required
+               "runtime compiletime"))
+             (native-test.write-file
+              SameFileDeclaration
+              (native-test.ppm-declaration
+               native.test.ppm-same-file
+               ["native-ppm-same-file.shen"]
+               []
+               native-test-ppm-same-file
+               "runtime compiletime"))
+             (native-test.write-file
+              InvalidDeclaration
+              (native-test.ppm-declaration
+               native.test.ppm-invalid
+               ["native-ppm-handler.shen" "native-ppm-invalid.shen"]
+               []
+               native-test-ppm-valid-before-error
+               "runtime compiletime"))
+             (native-test.write-file
+              UnregisterDeclaration
+              (native-test.ppm-declaration
+               native.test.ppm-unregister
+               ["native-ppm-handler.shen" "native-ppm-unregister.shen"]
+               []
+               "@native-test-ppm-two native-test-ppm-before-unregister"
+               "runtime compiletime"))
+             (map (function native-test.delete-file-if-exists)
+                  [ProviderObject RuntimeObject RootObject SameFileObject
+                   InvalidObject UnregisterObject AppObject])
+             (Assert "native PPM is inactive in its defining source"
+                     failed
+                     (trap-error
+                      (shen-scheme.compile-module
+                       SameFileDeclaration SameFileObject)
+                      (/. X failed)))
+             (Assert "failed native PPM compile restores handler names"
+                     InitialNames
+                     (native-test.ppm-handler-names))
+             (Assert "failed native PPM compile restores handlers"
+                     InitialHandlers
+                     (native-test.ppm-handlers))
+             (Assert "native PPM failure after registration is isolated"
+                     failed
+                     (trap-error
+                      (shen-scheme.compile-module
+                       InvalidDeclaration InvalidObject)
+                      (/. X failed)))
+             (Assert "later native PPM failure restores handler names"
+                     InitialNames
+                     (native-test.ppm-handler-names))
+             (Assert "later native PPM failure restores handlers"
+                     InitialHandlers
+                     (native-test.ppm-handlers))
+             (shen-scheme.build-module-app
+              RootDeclaration Dir AppObject)
+             (Assert "native PPM app build restores handler names"
+                     InitialNames
+                     (native-test.ppm-handler-names))
+             (Assert "native PPM app build restores handlers"
+                     InitialHandlers
+                     (native-test.ppm-handlers))
+             (shen-scheme.compile-module
+              ProviderDeclaration ProviderObject)
+             (shen-scheme.compile-module
+              RuntimeDeclaration RuntimeObject)
+             (shen-scheme.compile-module/in-dir
+              RootDeclaration RootObject Dir)
+             (shen-scheme.compile-module
+              UnregisterDeclaration UnregisterObject)
+             (Assert "native PPM compile restores handler names"
+                     InitialNames
+                     (native-test.ppm-handler-names))
+             (Assert "native PPM compile restores handlers"
+                     InitialHandlers
+                     (native-test.ppm-handlers))
+             (shen-scheme.native-load-compiled-for-compilation
+              RuntimeObject)
+             (Assert "runtime-only native PPM metadata stays inactive"
+                     InitialNames
+                     (native-test.ppm-handler-names))
+             (shen-scheme.native-load-compiled-for-compilation
+              ProviderObject)
+             (Assert "native PPM compiletime metadata registers handler"
+                     [native-test-ppm-handler | InitialNames]
+                     (native-test.ppm-handler-names))
+             (Assert "native PPM compiletime effects retain source order"
+                     [quote [1 2]]
+                     (native-test-ppm-ordered-macro (@p 1 2)))
+             (load CompiletimeFreshSource)
+             (native-test.ppm-cleanup)
+             (Assert "native PPM compiletime handler compiles new source"
+                     [1 2]
+                     (eval [native-test-ppm-after-compiletime-load [@p 1 2]]))
+             (Assert "native PPM handler remains private"
+                     unavailable
+                     (trap-error (native-test.ppm-call-private-handler)
+                                 (/. X unavailable)))
+             (shen-scheme.load-compiled RuntimeObject)
+             (Assert "native PPM runtime initializer registers handler"
+                     [native-test-ppm-handler | InitialNames]
+                     (native-test.ppm-handler-names))
+             (load RuntimeFreshSource)
+             (native-test.ppm-cleanup)
+             (Assert "native PPM runtime handler compiles new source"
+                     [1 2]
+                     (eval [native-test-ppm-after-runtime-load [@p 1 2]]))
+             (load ShadowSource)
+             (Assert "native PPM module matcher starts shadowed"
+                     stale
+                     (eval [native-test-ppm-required [@p 1 2]]))
+             (shen-scheme.load-module RootDeclaration Dir ObjectDir)
+             (Assert "native PPM later source matcher"
+                     [1 2]
+                     (eval [native-test-ppm-later [@p 1 2]]))
+             (Assert "native PPM required module matcher"
+                     [1 2]
+                     (eval [native-test-ppm-required [@p 1 2]]))
+             (native-test.ppm-cleanup)
+             (load ShadowSource)
+             (Assert "native PPM app matcher starts shadowed"
+                     stale
+                     (eval [native-test-ppm-required [@p 1 2]]))
+             (shen-scheme.load-compiled AppObject)
+             (Assert "native PPM module app matcher"
+                     [1 2]
+                     (eval [native-test-ppm-required [@p 1 2]]))
+             (native-test.ppm-cleanup)
+             (shen-scheme.load-compiled UnregisterObject)
+             (Assert "native PPM unregister is deferred to its file boundary"
+                     [1 2]
+                     (eval [native-test-ppm-before-unregister [@p 1 2]]))
+             (Assert "native PPM unregister replays at load"
+                     InitialNames
+                     (native-test.ppm-handler-names)))))))

--- a/scripts/run-native-tests.shen
+++ b/scripts/run-native-tests.shen
@@ -76,6 +76,11 @@
   X -> (+ X 1))
 ")
 
+(define native-test.module-home-source
+  -> "(define native-module-home-main
+  X -> (+ X 1))
+")
+
 (define native-test.module-typed-source
   -> "(define native-module-typed
   { number --> number }
@@ -253,6 +258,17 @@
   (name native.test.defaults)
   (sources tc- ~S)
   (extension shen/scheme))
+"
+                         (native-test.basename Source)))
+
+(define native-test.module-home-declaration-source
+  Source -> (make-string "(shen.module
+  (version 1)
+  (name native.test.home)
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-home-main)))
 "
                          (native-test.basename Source)))
 
@@ -976,6 +992,7 @@
           Lib "_build/native-tests/module-lib.shen"
           Main "_build/native-tests/module-main.shen"
           DefaultSource "_build/native-tests/module-default.shen"
+          HomeSource "_build/native-tests/module-home.shen"
           TypedSource "_build/native-tests/module-typed.shen"
           RuntimeOnlySource "_build/native-tests/module-runtime-only.shen"
           DeclaredSource "_build/native-tests/module-declared.shen"
@@ -992,6 +1009,7 @@
           RequirerSource "_build/native-tests/module-requirer.shen"
           Declaration "_build/native-tests/module-decl.shenmod"
           DefaultDeclaration "_build/native-tests/module-default.shenmod"
+          HomeDeclaration "_build/native-tests/module-home.shenmod"
           TypedDeclaration "_build/native-tests/module-typed.shenmod"
           RuntimeOnlyDeclaration "_build/native-tests/module-runtime-only.shenmod"
           DeclaredDeclaration "_build/native-tests/module-declared.shenmod"
@@ -1016,6 +1034,7 @@
           BadDeclaration "_build/native-tests/module-bad.shenmod"
           Object "_build/native-tests/module-decl.so"
           DefaultObject "_build/native-tests/module-default.so"
+          HomeObject "_build/native-tests/module-home.so"
           TypedObject "_build/native-tests/module-typed.so"
           RuntimeOnlyObject "_build/native-tests/module-runtime-only.so"
           RequiredObject
@@ -1031,6 +1050,7 @@
          (native-test.write-file Lib (native-test.module-lib-source))
          (native-test.write-file Main (native-test.module-main-source))
          (native-test.write-file DefaultSource (native-test.module-default-source))
+         (native-test.write-file HomeSource (native-test.module-home-source))
          (native-test.write-file TypedSource (native-test.module-typed-source))
          (native-test.write-file RuntimeOnlySource (native-test.module-runtime-only-source))
          (native-test.write-file DeclaredSource (native-test.module-declared-source))
@@ -1058,6 +1078,9 @@
          (native-test.write-file
           DefaultDeclaration
           (native-test.module-default-declaration-source DefaultSource))
+         (native-test.write-file
+          HomeDeclaration
+          (native-test.module-home-declaration-source HomeSource))
          (native-test.write-file
           TypedDeclaration
           (native-test.module-typed-declaration-source TypedSource))
@@ -1266,6 +1289,15 @@
              (Assert "module declaration default compile"
                      6
                      (eval [native-module-default-main 5]))
+             (let OldHome (value *home-directory*)
+               (do (set *home-directory* "_build/native-tests/")
+                   (shen-scheme.compile-module
+                    "module-home.shenmod" HomeObject)
+                   (shen-scheme.load-compiled HomeObject)
+                   (Assert "module declaration honors Shen home"
+                           42
+                           (eval [native-module-home-main 41]))
+                   (set *home-directory* OldHome)))
              (shen-scheme.compile-module TypedDeclaration TypedObject)
              (shen-scheme.load-compiled TypedObject)
              (Assert "module declaration typed call"

--- a/scripts/run-native-tests.shen
+++ b/scripts/run-native-tests.shen
@@ -698,7 +698,7 @@
            [shen-scheme.compile-module/in-dir 3]
            [shen-scheme.compile-module/emit 3]
            [shen-scheme.compile-module/emit/in-dir 4]
-           [shen-scheme.load-module 2]
+           [shen-scheme.load-module 3]
            [shen-scheme.build-app 3]
            [shen-scheme.build-app/wpo 3]
            [shen-scheme.build-app/profile 4]
@@ -971,7 +971,9 @@
                  (shen-scheme.file-exists? DebugScheme)))))
 
 (define native-test.run-module-declarations
-  -> (let Lib "_build/native-tests/module-lib.shen"
+  -> (let ModuleDir "_build/native-tests"
+          ObjectDir "_build/native-tests/module-objects"
+          Lib "_build/native-tests/module-lib.shen"
           Main "_build/native-tests/module-main.shen"
           DefaultSource "_build/native-tests/module-default.shen"
           TypedSource "_build/native-tests/module-typed.shen"
@@ -1016,9 +1018,12 @@
           DefaultObject "_build/native-tests/module-default.so"
           TypedObject "_build/native-tests/module-typed.so"
           RuntimeOnlyObject "_build/native-tests/module-runtime-only.so"
-          RequiredObject "_build/native-tests/native.test.required.so"
-          RequirerObject "_build/native-tests/native.test.requirer.so"
-          RequirerEmitObject "_build/native-tests/native.test.requirer.emit.so"
+          RequiredObject
+          "_build/native-tests/module-objects/native.test.required.so"
+          RequirerObject
+          "_build/native-tests/module-objects/native.test.requirer.so"
+          RequirerEmitObject
+          "_build/native-tests/module-objects/native.test.requirer.emit.so"
           RequirerScheme "_build/native-tests/native.test.requirer.emit.scm"
           Assert (/. Label Expected Actual
                     (native-test.assert-equal Label Expected Actual))
@@ -1290,10 +1295,11 @@
              (shen-scheme.compile-module/in-dir
               RequirerDeclaration
               RequirerObject
-              "_build/native-tests")
+              ModuleDir)
              (shen-scheme.load-module
               RequirerDeclaration
-              "_build/native-tests")
+              ModuleDir
+              ObjectDir)
              (Assert "module requires loaded dependency"
                      52
                      (eval [native-module-requirer 42]))
@@ -1301,7 +1307,7 @@
               RequirerDeclaration
               RequirerEmitObject
               RequirerScheme
-              "_build/native-tests")
+              ModuleDir)
              (shen-scheme.load-compiled RequirerEmitObject)
              (Assert "module requires emit compile"
                      53
@@ -1311,7 +1317,8 @@
                      (trap-error
                       (shen-scheme.load-module
                        CycleADeclaration
-                       "_build/native-tests")
+                       ModuleDir
+                       ObjectDir)
                       (/. E failed)))
              (Assert "module compile rejects mismatched required name"
                      MismatchError
@@ -1319,7 +1326,7 @@
                       (do (shen-scheme.compile-module/in-dir
                            MismatchRequirerDeclaration
                            RequirerObject
-                           "_build/native-tests")
+                           ModuleDir)
                           unexpected-success)
                       (/. E (error-to-string E))))
              (Assert "module load rejects mismatched required name"
@@ -1327,7 +1334,8 @@
                      (trap-error
                       (do (shen-scheme.load-module
                            MismatchRequirerDeclaration
-                           "_build/native-tests")
+                           ModuleDir
+                           ObjectDir)
                           unexpected-success)
                       (/. E (error-to-string E))))
              (Assert "module app rejects mismatched required name"
@@ -1335,10 +1343,87 @@
                      (trap-error
                       (do (shen-scheme.build-module-app
                            MismatchRequirerDeclaration
-                           "_build/native-tests"
+                           ModuleDir
                            RequirerObject)
                           unexpected-success)
                       (/. E (error-to-string E)))))))))
+
+(define native-test.run-nested-module-graph
+  -> (let ModuleDir "_build/native-tests/nested-modules"
+          ObjectDir "_build/native-tests/nested-objects"
+          NestedSource
+          "_build/native-tests/nested-modules/native.test/nested.shen"
+          RootSource "_build/native-tests/nested-modules/nested-root.shen"
+          NestedDeclaration
+          "_build/native-tests/nested-modules/native.test/nested.shenmod"
+          RootDeclaration
+          "_build/native-tests/nested-modules/native.test.nested-root.shenmod"
+          NestedObject
+          "_build/native-tests/nested-objects/native.test/nested.so"
+          RootObject
+          "_build/native-tests/nested-objects/native.test.nested-root.so"
+          WrongNestedObject
+          "_build/native-tests/nested-modules/native.test/nested.so"
+          WrongRootObject
+          "_build/native-tests/nested-modules/native.test.nested-root.so"
+          AppObject "_build/native-tests/nested-module-app.so"
+          Assert (/. Label Expected Actual
+                    (native-test.assert-equal Label Expected Actual))
+       (do
+         (native-test.write-file
+          NestedSource
+          "(define native-test-nested-helper
+  X -> (+ X 10))
+")
+         (native-test.write-file
+          RootSource
+          "(define native-test-nested-main
+  X -> (native-test-nested-helper X))
+")
+         (native-test.write-file
+          NestedDeclaration
+          (make-string "(shen.module
+  (version 1)
+  (name native.test/nested)
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-test-nested-helper)))
+"
+                       "nested.shen"))
+         (native-test.write-file
+          RootDeclaration
+          (make-string "(shen.module
+  (version 1)
+  (name native.test.nested-root)
+  (requires native.test/nested)
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-test-nested-main)))
+"
+                       "nested-root.shen"))
+         (native-test.delete-file-if-exists NestedObject)
+         (native-test.delete-file-if-exists RootObject)
+         (native-test.delete-file-if-exists WrongNestedObject)
+         (native-test.delete-file-if-exists WrongRootObject)
+         (shen-scheme.compile-module/in-dir
+          RootDeclaration RootObject ModuleDir)
+         (Assert "nested module compile needs no dependency object"
+                 false
+                 (shen-scheme.file-exists? NestedObject))
+         (let Result
+              (shen-scheme.build-module-app RootDeclaration ModuleDir AppObject)
+           (do
+             (shen-scheme.load-compiled (hd Result))
+             (Assert "nested module app traverses slash names"
+                     43
+                     (eval [native-test-nested-main 33]))))
+         (shen-scheme.compile-module NestedDeclaration NestedObject)
+         (shen-scheme.load-module RootDeclaration ModuleDir ObjectDir)
+         (Assert "nested module graph loads from separate roots"
+                 42
+                 (eval [native-test-nested-main 32])))))
 
 (define native-test.run-module-source-typechecking
   -> (let InvalidSource "_build/native-tests/module-tc-invalid.shen"
@@ -1627,6 +1712,7 @@
     (native-test.run-package-effects)
     (native-test.run-profiles)
     (native-test.run-module-declarations)
+    (native-test.run-nested-module-graph)
     (native-test.run-module-source-typechecking)
     (native-test.run-private-dependency-arity)
     (native-test.run-dependency-package-metadata)

--- a/scripts/run-native-tests.shen
+++ b/scripts/run-native-tests.shen
@@ -14,7 +14,12 @@
   _ _ -> false)
 
 (define native-test.unit-compiletime
-  [native-unit _ _ CT _] -> CT)
+  [native-unit _ _ CT _] -> (native-test.compiletime-scheme-forms CT))
+
+(define native-test.compiletime-scheme-forms
+  [] -> []
+  [[native-compiletime-group CT _] | Gs]
+  -> (append CT (native-test.compiletime-scheme-forms Gs)))
 
 (define native-test.compiletime-kind
   [_ [quote [defmacro | _]]] -> defmacro
@@ -1752,9 +1757,11 @@
     (native-test.run-sealed-redefinition)
     (native-test.run-app-builder)
     (native-test.run-module-app-builder)
+    (native-test.run-native-ppm)
     (native-test.run-core-regressions)
     (native-test.run-module-dependency-regressions)))
 
 (load "scripts/run-native-core-regression-tests.shen")
 (load "scripts/run-native-module-regression-tests.shen")
+(load "scripts/run-native-ppm-tests.shen")
 (native-test.run)

--- a/scripts/run-native-tests.shen
+++ b/scripts/run-native-tests.shen
@@ -52,6 +52,9 @@
                  (do (pr Body Out)
                      (close Out))))
 
+(define native-test.basename
+  (@s "_build/native-tests/" File) -> File)
+
 (define native-test.delete-file-if-exists
   File -> (shen-scheme.delete-file-if-exists File))
 
@@ -241,8 +244,8 @@
     (metadata compiletime runtime)
     (profile debug)))
 "
-                           Lib
-                           Main))
+                           (native-test.basename Lib)
+                           (native-test.basename Main)))
 
 (define native-test.module-default-declaration-source
   Source -> (make-string "(shen.module
@@ -251,7 +254,7 @@
   (sources tc- ~S)
   (extension shen/scheme))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-typed-declaration-source
   Source -> (make-string "(shen.module
@@ -262,7 +265,7 @@
     (mode sealed)
     (exports native-module-typed)))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-runtime-only-declaration-source
   Source -> (make-string "(shen.module
@@ -274,7 +277,7 @@
     (exports native-module-runtime-only)
     (metadata runtime)))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-declared-declaration-source
   Source -> (make-string "(shen.module
@@ -286,7 +289,7 @@
     (exports native-module-declared)
     (metadata runtime compiletime)))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-runtime-only-declared-declaration-source
   Source -> (make-string "(shen.module
@@ -298,7 +301,7 @@
     (exports native-module-runtime-only-declared)
     (metadata runtime)))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-compiletime-only-declaration-source
   Name Source -> (make-string "(shen.module
@@ -310,7 +313,7 @@
     (metadata compiletime)))
 "
                               Name
-                              Source))
+                              (native-test.basename Source)))
 
 (define native-test.module-source-kl-declaration-source
   Source -> (make-string "(shen.module
@@ -322,7 +325,7 @@
     (exports native-module-source-kl)
     (metadata runtime source-kl)))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-no-source-kl-declaration-source
   Source -> (make-string "(shen.module
@@ -334,7 +337,7 @@
     (exports native-module-no-source-kl)
     (metadata runtime compiletime)))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-required-declaration-source
   Source -> (make-string "(shen.module
@@ -345,7 +348,7 @@
     (mode sealed)
     (exports native-module-required-helper)))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-requirer-declaration-source
   Source -> (make-string "(shen.module
@@ -357,7 +360,7 @@
     (mode sealed)
     (exports native-module-requirer)))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-private-arity-declaration-source
   Source -> (make-string "(shen.module
@@ -368,7 +371,7 @@
     (mode sealed)
     (exports native-module-private-arity-export)))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-private-arity-main-declaration-source
   Source -> (make-string "(shen.module
@@ -380,7 +383,7 @@
     (mode sealed)
     (exports native-module-private-arity-main)))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-package-declaration-source
   Source -> (make-string "(shen.module
@@ -391,7 +394,7 @@
     (mode sealed)
     (exports native-module-package-export)))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-package-main-declaration-source
   Source -> (make-string "(shen.module
@@ -403,7 +406,7 @@
     (mode sealed)
     (exports native-module-package-main)))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-cycle-a-declaration-source
   Source -> (make-string "(shen.module
@@ -414,7 +417,7 @@
   (extension shen/scheme
     (mode sealed)))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-cycle-b-declaration-source
   Source -> (make-string "(shen.module
@@ -425,7 +428,7 @@
   (extension shen/scheme
     (mode sealed)))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-app-base-declaration-source
   Source -> (make-string "(shen.module
@@ -436,7 +439,7 @@
     (mode sealed)
     (exports native-module-app-base)))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-app-main-declaration-source
   Source -> (make-string "(shen.module
@@ -448,7 +451,7 @@
     (mode sealed)
     (exports native-module-app-main)))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-app-private-call-declaration-source
   Source -> (make-string "(shen.module
@@ -460,7 +463,7 @@
     (mode sealed)
     (exports native-module-app-private-probe)))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-app-missing-require-declaration-source
   Source -> (make-string "(shen.module
@@ -472,7 +475,7 @@
     (mode sealed)
     (exports native-module-app-main)))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-app-bad-export-declaration-source
   Source -> (make-string "(shen.module
@@ -483,7 +486,7 @@
     (mode sealed)
     (exports native-module-app-missing)))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.module-bad-declaration-source
   Source -> (make-string "(shen.module
@@ -492,7 +495,7 @@
   (sources tc- ~S)
   (unknown-field true))
 "
-                         Source))
+                         (native-test.basename Source)))
 
 (define native-test.compile-load
   Source Object Scheme -> (do (shen-scheme.compile-file/emit Source Object Scheme)
@@ -964,6 +967,11 @@
           (native-test.module-bad-declaration-source DefaultSource))
          (let Module (shen-scheme.native-read-module-declaration Declaration)
               Defaults (shen-scheme.native-read-module-declaration DefaultDeclaration)
+              ExpectedSources
+              [(shen-scheme.native-resolve-module-source-path
+                Declaration (native-test.basename Lib))
+               (shen-scheme.native-resolve-module-source-path
+                Declaration (native-test.basename Main))]
            (do
              (Assert "module declaration name"
                      native.test.module
@@ -975,8 +983,16 @@
                      debug
                      (shen-scheme.native-module-declaration-profile Module))
              (Assert "module declaration sources"
-                     [Lib Main]
+                     ExpectedSources
                      (shen-scheme.native-module-declaration-sources Module))
+             (Assert "module declaration resolved sources exist"
+                     true
+                     (every? (function shen-scheme.file-exists?)
+                             ExpectedSources))
+             (Assert "module declaration preserves absolute sources"
+                     (hd ExpectedSources)
+                     (shen-scheme.native-resolve-module-source-path
+                      Declaration (hd ExpectedSources)))
              (Assert "module declaration source modes"
                      [tc- tc-]
                      (shen-scheme.native-module-declaration-source-modes Module))

--- a/scripts/run-native-tests.shen
+++ b/scripts/run-native-tests.shen
@@ -260,7 +260,7 @@
   Source -> (make-string "(shen.module
   (version 1)
   (name native.test.typed)
-  (sources tc- ~S)
+  (sources tc+ ~S)
   (extension shen/scheme
     (mode sealed)
     (exports native-module-typed)))
@@ -496,6 +496,118 @@
   (unknown-field true))
 "
                          (native-test.basename Source)))
+
+(define native-test.module-invalid-typed-source
+  -> "(define native-module-tc-invalid
+  { number --> number }
+  X -> true)
+")
+
+(define native-test.module-tc-a-source
+  -> "(define native-module-tc-a
+  { number --> number }
+  X -> (+ X 1))
+")
+
+(define native-test.module-tc-b-source
+  -> "(define native-module-tc-b
+  { number --> number }
+  X -> (+ X 10))
+")
+
+(define native-test.module-tc-c-source
+  -> "(define native-module-tc-c
+  { number --> number }
+  X -> (+ X 100))
+")
+
+(define native-test.module-tc-ascribed-source
+  -> "(define native-module-tc-ascribed
+  { number --> number }
+  X -> (+ X 1))
+
+(native-module-tc-ascribed 41) : number
+")
+
+(define native-test.module-tc-order-declare-source
+  -> "(declare native-module-tc-order [string --> string])
+")
+
+(define native-test.module-tc-order-define-source
+  -> "(define native-module-tc-order
+  { number --> number }
+  X -> (+ X 1))
+")
+
+(define native-test.module-tc-before-synonym-source
+  -> "(define native-module-tc-before-synonym
+  { native-module-tc-number --> native-module-tc-number }
+  X -> (+ X 1))
+")
+
+(define native-test.module-tc-late-synonym-source
+  -> "(synonyms native-module-tc-number number)
+")
+
+(define native-test.module-tc-unchecked-ascription-source
+  -> "(set *native-module-tc-unchecked-ascription* 1)
+  : (set *native-module-tc-unchecked-ascription* 2)
+
+(define native-module-tc-unchecked-ascription
+  -> (value *native-module-tc-unchecked-ascription*))
+")
+
+(define native-test.module-single-source-tc-declaration-source
+  Name Mode Export Source -> (make-string "(shen.module
+  (version 1)
+  (name ~A)
+  (sources ~A ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports ~A)))
+"
+                                           Name Mode
+                                           (native-test.basename Source)
+                                           Export))
+
+(define native-test.module-tc-transition-declaration-source
+  A B C -> (make-string "(shen.module
+  (version 1)
+  (name native.test.tc-transition)
+  (sources tc+ ~S tc- ~S tc+ ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-tc-a
+             native-module-tc-b
+             native-module-tc-c)))
+"
+                         (native-test.basename A)
+                         (native-test.basename B)
+                         (native-test.basename C)))
+
+(define native-test.module-tc-order-declaration-source
+  Declare Define -> (make-string "(shen.module
+  (version 1)
+  (name native.test.tc-order)
+  (sources tc- ~S tc+ ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-tc-order)))
+"
+                                 (native-test.basename Declare)
+                                 (native-test.basename Define)))
+
+(define native-test.module-tc-late-synonym-declaration-source
+  Define Synonym -> (make-string "(shen.module
+  (version 1)
+  (name native.test.tc-late-synonym)
+  (sources tc+ ~S ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-tc-before-synonym)))
+"
+                                  (native-test.basename Define)
+                                  (native-test.basename Synonym)))
 
 (define native-test.compile-load
   Source Object Scheme -> (do (shen-scheme.compile-file/emit Source Object Scheme)
@@ -1157,6 +1269,152 @@
                        "_build/native-tests")
                       (/. E failed))))))))
 
+(define native-test.run-module-source-typechecking
+  -> (let InvalidSource "_build/native-tests/module-tc-invalid.shen"
+          InvalidDeclaration "_build/native-tests/module-tc-invalid.shenmod"
+          UncheckedDeclaration "_build/native-tests/module-tc-unchecked.shenmod"
+          InvalidObject "_build/native-tests/module-tc-invalid.so"
+          InvalidAppObject "_build/native-tests/module-tc-invalid-app.so"
+          UncheckedObject "_build/native-tests/module-tc-unchecked.so"
+          A "_build/native-tests/module-tc-a.shen"
+          B "_build/native-tests/module-tc-b.shen"
+          C "_build/native-tests/module-tc-c.shen"
+          TransitionDeclaration "_build/native-tests/module-tc-transition.shenmod"
+          TransitionObject "_build/native-tests/module-tc-transition.so"
+          AscribedSource "_build/native-tests/module-tc-ascribed.shen"
+          AscribedDeclaration "_build/native-tests/module-tc-ascribed.shenmod"
+          AscribedObject "_build/native-tests/module-tc-ascribed.so"
+          OrderDeclare "_build/native-tests/module-tc-order-declare.shen"
+          OrderDefine "_build/native-tests/module-tc-order-define.shen"
+          OrderDeclaration "_build/native-tests/module-tc-order.shenmod"
+          OrderObject "_build/native-tests/module-tc-order.so"
+          BeforeSynonym "_build/native-tests/module-tc-before-synonym.shen"
+          LateSynonym "_build/native-tests/module-tc-late-synonym.shen"
+          LateSynonymDeclaration
+          "_build/native-tests/module-tc-late-synonym.shenmod"
+          LateSynonymObject "_build/native-tests/module-tc-late-synonym.so"
+          UncheckedAscriptionSource
+          "_build/native-tests/module-tc-unchecked-ascription.shen"
+          UncheckedAscriptionDeclaration
+          "_build/native-tests/module-tc-unchecked-ascription.shenmod"
+          UncheckedAscriptionObject
+          "_build/native-tests/module-tc-unchecked-ascription.so"
+          Assert (/. Label Expected Actual
+                    (native-test.assert-equal Label Expected Actual))
+       (do
+         (native-test.write-file InvalidSource
+                                 (native-test.module-invalid-typed-source))
+         (native-test.write-file
+          InvalidDeclaration
+          (native-test.module-single-source-tc-declaration-source
+           native.test.tc-invalid tc+ native-module-tc-invalid InvalidSource))
+         (native-test.write-file
+          UncheckedDeclaration
+          (native-test.module-single-source-tc-declaration-source
+           native.test.tc-unchecked tc- native-module-tc-invalid InvalidSource))
+         (native-test.write-file A (native-test.module-tc-a-source))
+         (native-test.write-file B (native-test.module-tc-b-source))
+         (native-test.write-file C (native-test.module-tc-c-source))
+         (native-test.write-file
+          TransitionDeclaration
+          (native-test.module-tc-transition-declaration-source A B C))
+         (native-test.write-file AscribedSource
+                                 (native-test.module-tc-ascribed-source))
+         (native-test.write-file
+          AscribedDeclaration
+          (native-test.module-single-source-tc-declaration-source
+           native.test.tc-ascribed tc+ native-module-tc-ascribed
+           AscribedSource))
+         (native-test.write-file OrderDeclare
+                                 (native-test.module-tc-order-declare-source))
+         (native-test.write-file OrderDefine
+                                 (native-test.module-tc-order-define-source))
+         (native-test.write-file
+          OrderDeclaration
+          (native-test.module-tc-order-declaration-source
+           OrderDeclare OrderDefine))
+         (native-test.write-file
+          BeforeSynonym
+          (native-test.module-tc-before-synonym-source))
+         (native-test.write-file
+          LateSynonym
+          (native-test.module-tc-late-synonym-source))
+         (native-test.write-file
+          LateSynonymDeclaration
+          (native-test.module-tc-late-synonym-declaration-source
+           BeforeSynonym LateSynonym))
+         (native-test.write-file
+          UncheckedAscriptionSource
+          (native-test.module-tc-unchecked-ascription-source))
+         (native-test.write-file
+          UncheckedAscriptionDeclaration
+          (native-test.module-single-source-tc-declaration-source
+           native.test.tc-unchecked-ascription tc-
+           native-module-tc-unchecked-ascription
+           UncheckedAscriptionSource))
+         (Assert "module tc+ rejects invalid signed definition"
+                 failed
+                 (trap-error
+                  (shen-scheme.compile-module InvalidDeclaration InvalidObject)
+                  (/. E failed)))
+         (Assert "module app tc+ rejects invalid signed definition"
+                 failed
+                 (trap-error
+                  (shen-scheme.build-module-app
+                   InvalidDeclaration
+                   "_build/native-tests"
+                   InvalidAppObject)
+                  (/. E failed)))
+         (Assert "module tc+ cannot see a later synonym"
+                 failed
+                 (trap-error
+                  (shen-scheme.compile-module
+                   LateSynonymDeclaration LateSynonymObject)
+                  (/. E failed)))
+         (shen-scheme.compile-module UncheckedDeclaration UncheckedObject)
+         (shen-scheme.load-compiled UncheckedObject)
+         (Assert "module tc- permits invalid signed definition"
+                 true
+                 (eval [native-module-tc-invalid 0]))
+         (Assert "module tc- omits inline signature"
+                 []
+                 (assoc native-module-tc-invalid (value shen.*sigf*)))
+         (shen-scheme.compile-module
+          UncheckedAscriptionDeclaration UncheckedAscriptionObject)
+         (shen-scheme.load-compiled UncheckedAscriptionObject)
+         (Assert "module tc- retains top-level ascription forms"
+                 2
+                 (eval [native-module-tc-unchecked-ascription]))
+         (shen-scheme.compile-module TransitionDeclaration TransitionObject)
+         (shen-scheme.load-compiled TransitionObject)
+         (Assert "module source mode transitions run"
+                 126
+                 (eval [+ [native-module-tc-a 5]
+                          [+ [native-module-tc-b 5]
+                             [native-module-tc-c 5]]]))
+         (Assert "module tc+ first source retains inline signature"
+                 true
+                 (not (= [] (assoc native-module-tc-a
+                                   (value shen.*sigf*)))))
+         (Assert "module tc- middle source omits inline signature"
+                 []
+                 (assoc native-module-tc-b (value shen.*sigf*)))
+         (Assert "module tc+ final source retains inline signature"
+                 true
+                 (not (= [] (assoc native-module-tc-c
+                                   (value shen.*sigf*)))))
+         (shen-scheme.compile-module AscribedDeclaration AscribedObject)
+         (shen-scheme.load-compiled AscribedObject)
+         (Assert "module tc+ compiles top-level ascription once"
+                 42
+                 (eval [native-module-tc-ascribed 41]))
+         (shen-scheme.compile-module OrderDeclaration OrderObject)
+         (shen-scheme.load-compiled OrderObject)
+         (Assert "module signatures retain source order"
+                 number
+                 (shen.typecheck [native-module-tc-order 1]
+                                 number)))))
+
 (define native-test.run-app-builder
   -> (let Result (shen-scheme.build-app/profile
                    "tests/native/app-main.shen"
@@ -1298,6 +1556,7 @@
     (native-test.run-package-effects)
     (native-test.run-profiles)
     (native-test.run-module-declarations)
+    (native-test.run-module-source-typechecking)
     (native-test.run-private-dependency-arity)
     (native-test.run-dependency-package-metadata)
     (native-test.run-compatible-redefinition)

--- a/scripts/run-native-tests.shen
+++ b/scripts/run-native-tests.shen
@@ -362,6 +362,23 @@
 "
                          (native-test.basename Source)))
 
+(define native-test.module-mismatched-declaration-source
+  Source -> (make-string "(shen.module
+  (version 1)
+  (name native.test.other)
+  (sources tc- ~S))
+"
+                         (native-test.basename Source)))
+
+(define native-test.module-mismatch-requirer-declaration-source
+  Source -> (make-string "(shen.module
+  (version 1)
+  (name native.test.mismatch-requirer)
+  (requires native.test.mismatch)
+  (sources tc- ~S))
+"
+                         (native-test.basename Source)))
+
 (define native-test.module-private-arity-declaration-source
   Source -> (make-string "(shen.module
   (version 1)
@@ -986,6 +1003,14 @@
           RequirerDeclaration "_build/native-tests/native.test.requirer.shenmod"
           CycleADeclaration "_build/native-tests/native.test.cycle-a.shenmod"
           CycleBDeclaration "_build/native-tests/native.test.cycle-b.shenmod"
+          MismatchDeclaration
+          "_build/native-tests/native.test.mismatch.shenmod"
+          MismatchRequirerDeclaration
+          "_build/native-tests/module-mismatch-requirer.shenmod"
+          MismatchError
+          (make-string
+           "native module required native.test.mismatch but ~A declares native.test.other~%"
+           MismatchDeclaration)
           BadDeclaration "_build/native-tests/module-bad.shenmod"
           Object "_build/native-tests/module-decl.so"
           DefaultObject "_build/native-tests/module-default.so"
@@ -1075,6 +1100,12 @@
           CycleBDeclaration
           (native-test.module-cycle-b-declaration-source DefaultSource))
          (native-test.write-file
+          MismatchDeclaration
+          (native-test.module-mismatched-declaration-source DefaultSource))
+         (native-test.write-file
+          MismatchRequirerDeclaration
+          (native-test.module-mismatch-requirer-declaration-source DefaultSource))
+         (native-test.write-file
           BadDeclaration
           (native-test.module-bad-declaration-source DefaultSource))
          (let Module (shen-scheme.native-read-module-declaration Declaration)
@@ -1101,10 +1132,24 @@
                      true
                      (every? (function shen-scheme.file-exists?)
                              ExpectedSources))
-             (Assert "module declaration preserves absolute sources"
-                     (hd ExpectedSources)
-                     (shen-scheme.native-resolve-module-source-path
-                      Declaration (hd ExpectedSources)))
+             (Assert "module declaration rejects absolute sources"
+                     failed
+                     (trap-error
+                      (shen-scheme.native-parse-module-declaration
+                       [shen.module
+                        [version 1]
+                        [name absolute-source]
+                        [sources tc- (hd ExpectedSources)]])
+                      (/. E failed)))
+             (Assert "module declaration rejects empty sources"
+                     failed
+                     (trap-error
+                      (shen-scheme.native-parse-module-declaration
+                       [shen.module
+                        [version 1]
+                        [name empty-source]
+                        [sources tc- ""]])
+                      (/. E failed)))
              (Assert "module declaration source modes"
                      [tc- tc-]
                      (shen-scheme.native-module-declaration-source-modes Module))
@@ -1267,7 +1312,33 @@
                       (shen-scheme.load-module
                        CycleADeclaration
                        "_build/native-tests")
-                      (/. E failed))))))))
+                      (/. E failed)))
+             (Assert "module compile rejects mismatched required name"
+                     MismatchError
+                     (trap-error
+                      (do (shen-scheme.compile-module/in-dir
+                           MismatchRequirerDeclaration
+                           RequirerObject
+                           "_build/native-tests")
+                          unexpected-success)
+                      (/. E (error-to-string E))))
+             (Assert "module load rejects mismatched required name"
+                     MismatchError
+                     (trap-error
+                      (do (shen-scheme.load-module
+                           MismatchRequirerDeclaration
+                           "_build/native-tests")
+                          unexpected-success)
+                      (/. E (error-to-string E))))
+             (Assert "module app rejects mismatched required name"
+                     MismatchError
+                     (trap-error
+                      (do (shen-scheme.build-module-app
+                           MismatchRequirerDeclaration
+                           "_build/native-tests"
+                           RequirerObject)
+                          unexpected-success)
+                      (/. E (error-to-string E)))))))))
 
 (define native-test.run-module-source-typechecking
   -> (let InvalidSource "_build/native-tests/module-tc-invalid.shen"

--- a/scripts/run-native-tests.shen
+++ b/scripts/run-native-tests.shen
@@ -228,220 +228,268 @@
 ")
 
 (define native-test.module-declaration-source
-  Lib Main -> (make-string "(shen.aot.module
-  (profile debug)
-  (exports native-module-main)
-  (sources ~S ~S)
+  Lib Main -> (make-string "(shen.module
+  (version 1)
   (name native.test.module)
-  (mode sealed)
-  (metadata compiletime runtime))
+  (requires-features shen/scheme)
+  (sources tc- ~S ~S)
+  (extension example/tool
+    (flag true))
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-main)
+    (metadata compiletime runtime)
+    (profile debug)))
 "
                            Lib
                            Main))
 
 (define native-test.module-default-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.defaults)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme))
 "
                          Source))
 
 (define native-test.module-typed-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.typed)
-  (mode sealed)
-  (exports native-module-typed)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-typed)))
 "
                          Source))
 
 (define native-test.module-runtime-only-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.runtime-only)
-  (mode sealed)
-  (exports native-module-runtime-only)
-  (metadata runtime)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-runtime-only)
+    (metadata runtime)))
 "
                          Source))
 
 (define native-test.module-declared-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.declared)
-  (mode sealed)
-  (exports native-module-declared)
-  (metadata runtime compiletime)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-declared)
+    (metadata runtime compiletime)))
 "
                          Source))
 
 (define native-test.module-runtime-only-declared-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.runtime-only-declared)
-  (mode sealed)
-  (exports native-module-runtime-only-declared)
-  (metadata runtime)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-runtime-only-declared)
+    (metadata runtime)))
 "
                          Source))
 
 (define native-test.module-compiletime-only-declaration-source
-  Name Source -> (make-string "(shen.aot.module
+  Name Source -> (make-string "(shen.module
+  (version 1)
   (name ~A)
-  (mode sealed)
-  (metadata compiletime)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (metadata compiletime)))
 "
                               Name
                               Source))
 
 (define native-test.module-source-kl-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.source-kl)
-  (mode sealed)
-  (exports native-module-source-kl)
-  (metadata runtime source-kl)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-source-kl)
+    (metadata runtime source-kl)))
 "
                          Source))
 
 (define native-test.module-no-source-kl-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.no-source-kl)
-  (mode sealed)
-  (exports native-module-no-source-kl)
-  (metadata runtime compiletime)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-no-source-kl)
+    (metadata runtime compiletime)))
 "
                          Source))
 
 (define native-test.module-required-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.required)
-  (mode sealed)
-  (exports native-module-required-helper)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-required-helper)))
 "
                          Source))
 
 (define native-test.module-requirer-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.requirer)
-  (mode sealed)
   (requires native.test.required)
-  (exports native-module-requirer)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-requirer)))
 "
                          Source))
 
 (define native-test.module-private-arity-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.private-arity)
-  (mode sealed)
-  (exports native-module-private-arity-export)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-private-arity-export)))
 "
                          Source))
 
 (define native-test.module-private-arity-main-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.private-arity-main)
-  (mode sealed)
   (requires native.test.private-arity)
-  (exports native-module-private-arity-main)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-private-arity-main)))
 "
                          Source))
 
 (define native-test.module-package-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.package)
-  (mode sealed)
-  (exports native-module-package-export)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-package-export)))
 "
                          Source))
 
 (define native-test.module-package-main-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.package-main)
-  (mode sealed)
   (requires native.test.package)
-  (exports native-module-package-main)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-package-main)))
 "
                          Source))
 
 (define native-test.module-cycle-a-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.cycle-a)
-  (mode sealed)
   (requires native.test.cycle-b)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)))
 "
                          Source))
 
 (define native-test.module-cycle-b-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.cycle-b)
-  (mode sealed)
   (requires native.test.cycle-a)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)))
 "
                          Source))
 
 (define native-test.module-app-base-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.app-base)
-  (mode sealed)
-  (exports native-module-app-base)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-app-base)))
 "
                          Source))
 
 (define native-test.module-app-main-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.app-main)
-  (mode sealed)
   (requires native.test.app-base)
-  (exports native-module-app-main)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-app-main)))
 "
                          Source))
 
 (define native-test.module-app-private-call-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.app-private-call)
-  (mode sealed)
   (requires native.test.app-base)
-  (exports native-module-app-private-probe)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-app-private-probe)))
 "
                          Source))
 
 (define native-test.module-app-missing-require-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.app-missing-require)
-  (mode sealed)
   (requires native.test.app-missing)
-  (exports native-module-app-main)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-app-main)))
 "
                          Source))
 
 (define native-test.module-app-bad-export-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.app-bad-export)
-  (mode sealed)
-  (exports native-module-app-missing)
-  (sources ~S))
+  (sources tc- ~S)
+  (extension shen/scheme
+    (mode sealed)
+    (exports native-module-app-missing)))
 "
                          Source))
 
 (define native-test.module-bad-declaration-source
-  Source -> (make-string "(shen.aot.module
+  Source -> (make-string "(shen.module
+  (version 1)
   (name native.test.bad)
-  (sources ~S)
+  (sources tc- ~S)
   (unknown-field true))
 "
                          Source))
@@ -490,8 +538,14 @@
                            [[native-test-shared native-test-first]]
                            [[native-test-shared 1]]]])
           BadDependency
-          [module-declaration native.test.bad-dependency compatible
-           [Source] [] [native-test-add] [] release]
+          (shen-scheme.native-parse-module-declaration
+           [shen.module
+            [version 1]
+            [name native.test.bad-dependency]
+            [sources tc- Source]
+            [extension shen/scheme
+             [mode compatible]
+             [exports native-test-add]]])
        (do
          (native-test.assert-facade-arities
           [[shen-scheme.native-compile-profile-options 1]
@@ -576,10 +630,13 @@
          (native-test.assert-equal
           "compatible declaration name skips source key"
           skip
-          (shen-scheme.native-module-declaration-module-name/mode
-           [module-declaration native.test.missing-key compatible
-            ["_build/native-tests/missing-key-source.shen"]
-            [] infer-all [] release]
+         (shen-scheme.native-module-declaration-module-name/mode
+           (shen-scheme.native-parse-module-declaration
+            [shen.module
+             [version 1]
+             [name native.test.missing-key]
+             [sources tc-
+              "_build/native-tests/missing-key-source.shen"]])
            compatible)))))
 
 (define native-test.run-private-dependency-arity
@@ -920,6 +977,16 @@
              (Assert "module declaration sources"
                      [Lib Main]
                      (shen-scheme.native-module-declaration-sources Module))
+             (Assert "module declaration source modes"
+                     [tc- tc-]
+                     (shen-scheme.native-module-declaration-source-modes Module))
+             (Assert "module declaration required features"
+                     [shen/scheme]
+                     (shen-scheme.native-module-declaration-required-features Module))
+             (Assert "module declaration preserves foreign extensions"
+                     [[flag true]]
+                     (shen-scheme.native-module-declaration-extension
+                      example/tool Module))
              (Assert "module declaration exports"
                      [native-module-main]
                      (shen-scheme.native-module-declaration-exports Module))
@@ -936,6 +1003,72 @@
                      failed
                      (trap-error
                       (shen-scheme.native-read-module-declaration BadDeclaration)
+                      (/. E failed)))
+             (Assert "module declaration rejects legacy head"
+                     failed
+                     (trap-error
+                      (shen-scheme.native-parse-module-declaration
+                       [shen.aot.module
+                        [name legacy]
+                        [sources tc- "legacy.shen"]])
+                      (/. E failed)))
+             (Assert "module declaration requires version one"
+                     failed
+                     (trap-error
+                      (shen-scheme.native-parse-module-declaration
+                       [shen.module
+                        [version 2]
+                        [name future]
+                        [sources tc- "future.shen"]])
+                      (/. E failed)))
+             (Assert "module declaration requires source mode"
+                     failed
+                     (trap-error
+                      (shen-scheme.native-parse-module-declaration
+                       [shen.module
+                        [version 1]
+                        [name unmarked]
+                        [sources "unmarked.shen"]])
+                      (/. E failed)))
+             (Assert "module declaration rejects unavailable features"
+                     failed
+                     (trap-error
+                      (shen-scheme.native-parse-module-declaration
+                       [shen.module
+                        [version 1]
+                        [name missing-feature]
+                        [requires-features native.test.missing-feature]
+                        [sources tc- "missing-feature.shen"]])
+                      (/. E failed)))
+             (Assert "module declaration rejects dangling source mode"
+                     failed
+                     (trap-error
+                      (shen-scheme.native-parse-module-declaration
+                       [shen.module
+                        [version 1]
+                        [name dangling-mode]
+                        [sources tc- "one.shen" tc+]])
+                      (/. E failed)))
+             (Assert "module declaration rejects duplicate extensions"
+                     failed
+                     (trap-error
+                      (shen-scheme.native-parse-module-declaration
+                       [shen.module
+                        [version 1]
+                        [name duplicate-extension]
+                        [sources tc- "duplicate-extension.shen"]
+                        [extension example/tool]
+                        [extension example/tool]])
+                      (/. E failed)))
+             (Assert "module declaration validates Shen/Scheme extension"
+                     failed
+                     (trap-error
+                      (shen-scheme.native-parse-module-declaration
+                       [shen.module
+                        [version 1]
+                        [name bad-extension]
+                        [sources tc- "bad-extension.shen"]
+                        [extension shen/scheme [unknown true]]])
                       (/. E failed)))
              (Assert "module metadata accepts arbitrary effects"
                      []

--- a/scripts/run-programmable-pattern-matching-tests.shen
+++ b/scripts/run-programmable-pattern-matching-tests.shen
@@ -1,0 +1,87 @@
+(define ppm-test.assert-equal
+  Label Expected Expected -> (output "ok - ~A~%" Label)
+  Label Expected Actual -> (error "~A: expected ~R, got ~R~%" Label Expected Actual))
+
+(define ppm-test.two-handler
+  Self AddTest Bind [ppm-test.two A B]
+  -> (do (AddTest [tuple? Self])
+         (Bind A [fst Self])
+         (Bind B [snd Self]))
+  _ _ _ _ -> (fail))
+
+(ppm-test.assert-equal
+  "custom pattern compiler initialized at startup"
+  true
+  (not (= false (value shen.*custom-pattern-compiler*))))
+
+(ppm-test.assert-equal
+  "custom pattern reducer initialized at startup"
+  true
+  (not (= false (value shen.*custom-pattern-reducer*))))
+
+(ppm-test.assert-equal
+  "handler registry initialized at startup"
+  []
+  (value shen.x.programmable-pattern-matching.*pattern-handlers-reg*))
+
+(shen.x.programmable-pattern-matching.register-handler ppm-test.two-handler)
+(shen.x.programmable-pattern-matching.register-handler ppm-test.two-handler)
+
+(ppm-test.assert-equal
+  "handler registration is idempotent"
+  [ppm-test.two-handler]
+  (value shen.x.programmable-pattern-matching.*pattern-handlers-reg*))
+
+(load "tests/programmable-pattern-matching/code.shen")
+
+(ppm-test.assert-equal
+  "simple custom pattern"
+  [1 2]
+  (ppm-test.match-simple (@p 1 2)))
+
+(ppm-test.assert-equal
+  "repeated variable success"
+  same
+  (ppm-test.match-repeat (@p 1 1)))
+
+(ppm-test.assert-equal
+  "repeated variable failure"
+  different
+  (ppm-test.match-repeat (@p 1 2)))
+
+(ppm-test.assert-equal
+  "nested custom pattern"
+  [1 2 3]
+  (ppm-test.match-nested (@p (@p 1 2) 3)))
+
+(ppm-test.assert-equal
+  "built-in patterns still work"
+  [1 [2 3]]
+  (ppm-test.match-cons [1 2 3]))
+
+(ppm-test.assert-equal
+  "handler can be unregistered"
+  ppm-test.two-handler
+  (shen.x.programmable-pattern-matching.unregister-handler ppm-test.two-handler))
+
+(ppm-test.assert-equal
+  "handler registry is empty after unregister"
+  []
+  (value shen.x.programmable-pattern-matching.*pattern-handlers-reg*))
+
+(load "tests/programmable-pattern-matching/after-unregister.shen")
+
+(ppm-test.assert-equal
+  "compiled custom patterns keep their behavior"
+  [1 2]
+  (ppm-test.match-simple (@p 1 2)))
+
+(ppm-test.assert-equal
+  "unregistered patterns no longer match custom values"
+  no
+  (ppm-test.match-after-unregister (@p 1 2)))
+
+(ppm-test.assert-equal
+  "unregistered patterns retain ordinary list semantics"
+  [1 2]
+  (ppm-test.match-after-unregister [ppm-test.two 1 2]))

--- a/src/native-app.shen
+++ b/src/native-app.shen
@@ -126,8 +126,9 @@
 
 (define native-module-app-sources
   [] -> []
-  [[module-declaration _ _ Ss _ _ _ _] | Ds]
-  -> (append Ss (native-module-app-sources Ds)))
+  [D | Ds]
+  -> (append (native-module-declaration-sources D)
+             (native-module-app-sources Ds)))
 
 (define native-module-app-key
   Ds Os WPO? -> ((foreign scm.shen-scheme-native-key)
@@ -214,19 +215,24 @@
 
 (define native-module-app-module-forms*
   [] _ _ Ms Fs -> [Ms Fs]
-  [[module-declaration N _ Ss Rs Xs MD _] | Ds] App I Ms Fs
-  -> (do (native-module-app-validate-required-exports Rs Ms)
-         (let RM (native-module-app-required-visible-map Rs Ms)
-              As (native-module-app-required-visible-arities Rs Ms)
-              U (native-sources->unit/with-arities Ss As)
-              KL (native-unit-kl U)
-              LM (native-app-local-map KL I)
-              CXs (native-validate-exports Xs LM)
-              XM (native-exported-local-map LM CXs)
-              AM (native-exported-arities KL CXs)
-              F (native-module-app-module-form App I CXs MD U LM XM RM)
-              MM [module-app-map N I XM AM]
-           (native-module-app-module-forms*
-            Ds App (+ I 1) [MM | Ms] [F | Fs]))))
+  [D | Ds] App I Ms Fs
+  -> (let N (native-module-declaration-name D)
+          Ss (native-module-declaration-sources D)
+          Rs (native-module-declaration-requires D)
+          Xs (native-module-declaration-exports D)
+          MD (native-module-declaration-metadata D)
+       (do (native-module-app-validate-required-exports Rs Ms)
+           (let RM (native-module-app-required-visible-map Rs Ms)
+                As (native-module-app-required-visible-arities Rs Ms)
+                U (native-sources->unit/with-arities Ss As)
+                KL (native-unit-kl U)
+                LM (native-app-local-map KL I)
+                CXs (native-validate-exports Xs LM)
+                XM (native-exported-local-map LM CXs)
+                AM (native-exported-arities KL CXs)
+                F (native-module-app-module-form App I CXs MD U LM XM RM)
+                MM [module-app-map N I XM AM]
+             (native-module-app-module-forms*
+              Ds App (+ I 1) [MM | Ms] [F | Fs])))))
 
 )

--- a/src/native-app.shen
+++ b/src/native-app.shen
@@ -217,14 +217,14 @@
   [] _ _ Ms Fs -> [Ms Fs]
   [D | Ds] App I Ms Fs
   -> (let N (native-module-declaration-name D)
-          Ss (native-module-declaration-sources D)
+          Ss (native-module-declaration-source-specs D)
           Rs (native-module-declaration-requires D)
           Xs (native-module-declaration-exports D)
           MD (native-module-declaration-metadata D)
        (do (native-module-app-validate-required-exports Rs Ms)
            (let RM (native-module-app-required-visible-map Rs Ms)
                 As (native-module-app-required-visible-arities Rs Ms)
-                U (native-sources->unit/with-arities Ss As)
+                U (native-module-sources->unit/with-arities Ss As)
                 KL (native-unit-kl U)
                 LM (native-app-local-map KL I)
                 CXs (native-validate-exports Xs LM)

--- a/src/native-app.shen
+++ b/src/native-app.shen
@@ -193,8 +193,9 @@
           VM (append LM RM)
           Ds (native-compile-kl-forms app VM KL)
           Init (native-compile-kl-forms app VM Is)
+          CF (native-compiletime-forms app VM CT)
           RT (native-module-runtime-forms KL LM Xs MD Ps)
-          Meta (native-module-compiletime-forms KL CT MD)
+          Meta (native-module-compiletime-forms KL CF MD)
           Run (native-module-init-forms Init)
        [module M (native-app-exports XM RI CI II)
         | (append Ds [[define [RI] | RT]

--- a/src/native-app.shen
+++ b/src/native-app.shen
@@ -115,9 +115,7 @@
 (define native-module-app-requirements
   [] _ _ L Ds -> [L Ds]
   [M | Ms] Dir Stack L Ds
-  -> (let P (native-module-declaration-path Dir M)
-          P (native-require-existing-file P "required module declaration")
-          D (native-read-module-declaration P)
+  -> (let D (native-read-required-module-declaration M Dir)
           R (native-module-app-declarations* D Dir Stack L Ds)
        (native-module-app-requirements
         Ms Dir Stack

--- a/src/native-codegen.shen
+++ b/src/native-codegen.shen
@@ -3,7 +3,8 @@
 
 (package shen-scheme
  [compatible sealed infer-all runtime compiletime source-kl
-  native-unit defun define quote module import if begin define-top-level-value skip
+  native-unit native-compiletime-group
+  defun define quote module import if begin define-top-level-value skip
   update-lambda-table install-runtime! install-compiletime! install-init! loaded
   shen-scheme-native-load-init?
   _scm.prefix-op _scm.kl->scheme _scm.with-native-context
@@ -31,10 +32,18 @@
   [native-unit KL Is CT Ps] MD
   -> (let Ds (native-compile-kl-forms compatible [] KL)
           RT (native-runtime-metadata-forms KL MD)
-          Meta (native-compiletime-metadata-forms KL CT MD)
+          CF (native-compiletime-forms compatible [] CT)
+          Meta (native-compiletime-metadata-forms KL CF MD)
           Init (native-compile-kl-forms compatible [] Is)
        (append Ds RT Ps Meta
                [(native-load-init-form (append Init [[quote loaded]]))])))
+
+(define native-compiletime-forms
+  _ _ [] -> []
+  M LM [[native-compiletime-group CT Es] | Gs]
+  -> (append CT
+             (append (native-compile-kl-forms M LM Es)
+                     (native-compiletime-forms M LM Gs))))
 
 (define native-compile-mode
   compatible -> compatible
@@ -151,8 +160,9 @@
           CXs (native-validate-exports Xs LM)
           Ds (native-compile-kl-forms sealed LM KL)
           Init (native-compile-kl-forms sealed LM Is)
+          CF (native-compiletime-forms sealed LM CT)
           RT (native-module-runtime-forms KL LM CXs MD Ps)
-          Meta (native-module-compiletime-forms KL CT MD)
+          Meta (native-module-compiletime-forms KL CF MD)
           Run (native-module-init-forms Init)
        [(native-sealed-module-form M Ds RT Meta Run)
         [import M] [install-runtime!] [install-compiletime!]

--- a/src/native-modules.shen
+++ b/src/native-modules.shen
@@ -6,7 +6,7 @@
   shen/scheme mode exports metadata profile tc+ tc-
   module-declaration infer-all runtime compiletime source-kl
   compatible sealed release skip
-  update-lambda-table
+  quote update-lambda-table _scm.prefix-op
   scm.shen-scheme-native-key scm.shen-scheme-load-compiled
   scm.shen-scheme-load-compiled-for-compilation
   scm.shen-scheme-resolve-module-source
@@ -187,12 +187,6 @@
   Es -> Es where (element? shen/scheme (native-module-extension-ids Es))
   Es -> (append Es [(native-default-shen-scheme-extension)]))
 
-(define native-module-source-mode
-  [module-source M _] -> M)
-
-(define native-module-source-path
-  [module-source _ P] -> P)
-
 (define native-resolve-module-source-path
   D S -> ((foreign scm.shen-scheme-resolve-module-source) D S))
 
@@ -294,7 +288,8 @@
   D -> (let M (native-module-declaration-mode D)
          (native-scheme-forms*
           (native-module-declaration-module-name/mode D M)
-          (native-sources->unit (native-module-declaration-sources D))
+          (native-module-sources->unit
+           (native-module-declaration-source-specs D))
           M
           (native-module-declaration-exports D)
           (native-module-declaration-metadata D))))
@@ -349,20 +344,33 @@
   [[F A] | As] -> (do (native-register-arities As)
                        (update-lambda-table F A)))
 
-(define native-sources->unit/with-arities
-  Ss As -> (with-native-compiler-state
-            (freeze (native-sources->unit/with-arities* Ss As))))
+(define native-record-package-form
+  [F [quote N] [quote Xs]] -> (shen.record-external N Xs)
+    where (= F (_scm.prefix-op shen.record-external))
+  [F [quote N] [quote Xs] [quote Fs]] -> (shen.record-internal N Xs Fs)
+    where (= F (_scm.prefix-op shen.record-internal)))
 
-(define native-sources->unit/with-arities*
-  Ss As -> (let X (native-expand-forms (native-read-source-forms Ss))
-                O (value *property-vector*)
+(define native-record-package-forms
+  [] -> skip
+  [F | Fs] -> (do (native-record-package-form F)
+                  (native-record-package-forms Fs)))
+
+(define native-module-sources->unit/with-arities
+  Ss As -> (with-native-compiler-state
+            (freeze (native-module-sources->unit/with-arities* Ss As))))
+
+(define native-module-sources->unit/with-arities*
+  Ss As -> (let O (value *property-vector*)
                 N (native-copy-property-vector O)
-             ((foreign scm.dynamic-wind)
-              (freeze (set *property-vector* N))
-              (freeze
-               (do (native-register-arities As)
-                   (native-source-data->unit (native-process-expanded X))))
-              (freeze (set *property-vector* O)))))
+                U ((foreign scm.dynamic-wind)
+                   (freeze (set *property-vector* N))
+                   (freeze
+                    (do (native-register-arities As)
+                        (native-source-data->unit
+                         (native-process-module-sources Ss))))
+                   (freeze (set *property-vector* O)))
+             (do (native-record-package-forms (native-unit-packages U))
+                 U)))
 
 (define native-defun-arity
   [defun F As _] -> [F (length As)])
@@ -375,7 +383,8 @@
   compatible _ Xs -> (error "native compiler explicit exports require sealed mode, got: ~S~%" Xs)
     where (not (= Xs infer-all))
   _ Ss Xs
-  -> (let KL (native-unit-kl (native-sources->unit/with-arities Ss []))
+  -> (let KL (native-unit-kl
+              (native-module-sources->unit/with-arities Ss []))
           CXs (native-validate-exports Xs (native-local-map KL))
        (native-register-arities (native-exported-arities KL CXs))))
 
@@ -383,7 +392,7 @@
   D Dir Stack L
   -> (let N (native-module-declaration-name D)
           M (native-module-declaration-mode D)
-          Ss (native-module-declaration-sources D)
+          Ss (native-module-declaration-source-specs D)
           Rs (native-module-declaration-requires D)
           Xs (native-module-declaration-exports D)
        (if (element? N Stack)

--- a/src/native-modules.shen
+++ b/src/native-modules.shen
@@ -2,7 +2,8 @@
 \* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
 
 (package shen-scheme
- [shen.aot.module name mode sources requires exports metadata profile
+ [shen.module version name sources requires requires-features extension
+  shen/scheme mode exports metadata profile tc+ tc-
   module-declaration infer-all runtime compiletime source-kl
   compatible sealed release skip
   update-lambda-table
@@ -21,74 +22,99 @@
         (native-single-form P (read-file-unprocessed P))))
 
 (define native-parse-module-declaration
-  [shen.aot.module | Fs] -> (native-parse-module-fields
-                             Fs [] (fail) compatible [] [] infer-all
-                             [runtime compiletime] release)
-  F -> (error "native module declaration expected shen.aot.module form, got: ~S~%" F))
+  [shen.module | Fs] -> (native-parse-module-fields
+                         Fs [] (fail) (fail) (fail) [] [] [])
+  F -> (error "module declaration expected shen.module form, got: ~S~%" F))
 
 (define native-add-seen-field
   F Seen -> (if (element? F Seen)
-                (error "native module declaration has duplicate field: ~A~%" F)
+                (error "module declaration has duplicate field: ~A~%" F)
                 [F | Seen]))
 
 (define native-parse-module-fields
-  [] _ N M Ss Rs Xs MD P
-  -> (native-finalize-module-declaration N M Ss Rs Xs MD P)
-  [[name N] | Fs] Seen _ M Ss Rs Xs MD P
+  [] _ V N Ss Rs RFs Es
+  -> (native-finalize-module-declaration V N Ss Rs RFs Es)
+  [[version V] | Fs] Seen _ N Ss Rs RFs Es
+  -> (native-parse-module-fields Fs (native-add-seen-field version Seen)
+                                 V N Ss Rs RFs Es)
+  [[name N] | Fs] Seen V _ Ss Rs RFs Es
   -> (native-parse-module-fields Fs (native-add-seen-field name Seen)
-                                 N M Ss Rs Xs MD P)
-  [[mode M] | Fs] Seen N _ Ss Rs Xs MD P
-  -> (native-parse-module-fields Fs (native-add-seen-field mode Seen)
-                                 N M Ss Rs Xs MD P)
-  [[sources | Ss] | Fs] Seen N M _ Rs Xs MD P
+                                 V N Ss Rs RFs Es)
+  [[sources | Ss] | Fs] Seen V N _ Rs RFs Es
   -> (native-parse-module-fields Fs (native-add-seen-field sources Seen)
-                                 N M Ss Rs Xs MD P)
-  [[requires | Rs] | Fs] Seen N M Ss _ Xs MD P
+                                 V N Ss Rs RFs Es)
+  [[requires | Rs] | Fs] Seen V N Ss _ RFs Es
   -> (native-parse-module-fields Fs (native-add-seen-field requires Seen)
-                                 N M Ss Rs Xs MD P)
-  [[exports infer-all] | Fs] Seen N M Ss Rs _ MD P
-  -> (native-parse-module-fields Fs (native-add-seen-field exports Seen)
-                                 N M Ss Rs infer-all MD P)
-  [[exports | Xs] | Fs] Seen N M Ss Rs _ MD P
-  -> (native-parse-module-fields Fs (native-add-seen-field exports Seen)
-                                 N M Ss Rs Xs MD P)
-  [[metadata | MD] | Fs] Seen N M Ss Rs Xs _ P
-  -> (native-parse-module-fields Fs (native-add-seen-field metadata Seen)
-                                 N M Ss Rs Xs MD P)
-  [[profile P] | Fs] Seen N M Ss Rs Xs MD _
-  -> (native-parse-module-fields Fs (native-add-seen-field profile Seen)
-                                 N M Ss Rs Xs MD P)
-  [F | _] _ _ _ _ _ _ _ _
-  -> (error "native module declaration has unknown or malformed field: ~S~%" F))
+                                 V N Ss Rs RFs Es)
+  [[requires-features | RFs] | Fs] Seen V N Ss Rs _ Es
+  -> (native-parse-module-fields
+      Fs (native-add-seen-field requires-features Seen)
+      V N Ss Rs RFs Es)
+  [[extension Id | Xs] | Fs] Seen V N Ss Rs RFs Es
+  -> (native-parse-module-fields
+      Fs Seen V N Ss Rs RFs
+      (native-add-module-extension
+       (native-parse-module-extension Id Xs) Es))
+  [F | _] _ _ _ _ _ _ _
+  -> (error "module declaration has unknown or malformed field: ~S~%" F))
 
 (define native-finalize-module-declaration
-  N M Ss Rs Xs MD P
-  -> (error "native module declaration requires a name field~%")
+  V N Ss Rs RFs Es
+  -> (error "module declaration requires (version 1)~%")
+    where (not (= V 1))
+  V N Ss Rs RFs Es
+  -> (error "module declaration requires a name field~%")
     where (= N (fail))
-  N M Ss Rs Xs MD P
-  -> [module-declaration (native-module-symbol name N) (native-compile-mode M)
-      (native-source-list Ss) (native-symbol-list requires Rs)
-      (native-exports Xs) (native-metadata-list MD)
-      (native-compile-profile P)])
+  V N Ss Rs RFs Es
+  -> (error "module declaration requires a sources field~%")
+    where (= Ss (fail))
+  V N Ss Rs RFs Es
+  -> (let RFs (native-symbol-list requires-features RFs)
+       (do (native-require-features RFs)
+           [module-declaration
+            (native-module-symbol name N)
+            (native-source-list Ss)
+            (native-symbol-list requires Rs)
+            RFs
+            (native-finalize-module-extensions (reverse Es))])))
 
 (define native-module-symbol
   _ X -> X where (symbol? X)
-  F X -> (error "native module declaration field ~A expected a symbol, got: ~S~%" F X))
+  F X -> (error "module declaration field ~A expected a symbol, got: ~S~%" F X))
 
 (define native-source-list
-  [] -> (error "native module declaration requires at least one source~%")
-  Ss -> Ss where (native-string-list? Ss)
-  Ss -> (error "native module declaration sources must be strings, got: ~S~%" Ss))
+  Ss -> (native-source-list* Ss (fail) [] false))
 
-(define native-string-list?
-  [] -> true
-  [S | Ss] -> (and (string? S) (native-string-list? Ss))
-  _ -> false)
+(define native-source-list*
+  [] _ [] _ -> (error "module declaration requires at least one source~%")
+  [] M _ true
+  -> (error "module declaration source mode ~A must be followed by a source~%" M)
+  [] _ Ss false -> (reverse Ss)
+  [tc+ | _] M _ true
+  -> (error "module declaration source mode ~A must be followed by a source~%" M)
+  [tc- | _] M _ true
+  -> (error "module declaration source mode ~A must be followed by a source~%" M)
+  [tc+ | Ss] _ Out false -> (native-source-list* Ss tc+ Out true)
+  [tc- | Ss] _ Out false -> (native-source-list* Ss tc- Out true)
+  [S | Ss] M Out _
+  -> (error "module declaration source ~S must follow tc+ or tc-~%" S)
+    where (= M (fail))
+  [S | Ss] M Out _
+  -> (native-source-list* Ss M [[module-source M S] | Out] false)
+    where (string? S)
+  [S | _] _ _ _
+  -> (error "module declaration source must be a string, got: ~S~%" S))
 
 (define native-symbol-list
   _ [] -> []
   F [X | Xs] -> [X | (native-symbol-list F Xs)] where (symbol? X)
-  F Xs -> (error "native module declaration field ~A expected symbols, got: ~S~%" F Xs))
+  F Xs -> (error "module declaration field ~A expected symbols, got: ~S~%" F Xs))
+
+(define native-require-features
+  [] -> skip
+  [F | Fs] -> (if (element? F (shen.x.features.current))
+                  (native-require-features Fs)
+                  (error "module declaration requires unavailable feature: ~A~%" F)))
 
 (define native-exports
   infer-all -> infer-all
@@ -97,38 +123,147 @@
 (define native-metadata-list
   [] -> []
   [M | Ms] -> [(native-metadata M) | (native-metadata-list Ms)]
-  MD -> (error "native module declaration metadata must be symbols, got: ~S~%" MD))
+  MD -> (error "shen/scheme extension metadata must be symbols, got: ~S~%" MD))
 
 (define native-metadata
   runtime -> runtime
   compiletime -> compiletime
   source-kl -> source-kl
-  M -> (error "native module declaration expected metadata runtime, compiletime, or source-kl, got: ~S~%" M))
+  M -> (error "shen/scheme extension expected metadata runtime, compiletime, or source-kl, got: ~S~%" M))
+
+(define native-parse-module-extension
+  shen/scheme Fs -> [module-extension shen/scheme
+                     (native-parse-shen-scheme-extension
+                      Fs [] compatible infer-all
+                      [runtime compiletime] release)]
+  Id Fs -> [module-extension (native-module-symbol extension Id) Fs])
+
+(define native-parse-shen-scheme-extension
+  [] _ M Xs MD P -> [shen-scheme-extension M Xs MD P]
+  [[mode M] | Fs] Seen _ Xs MD P
+  -> (native-parse-shen-scheme-extension
+      Fs (native-add-seen-field mode Seen)
+      (native-compile-mode M) Xs MD P)
+  [[exports infer-all] | Fs] Seen M _ MD P
+  -> (native-parse-shen-scheme-extension
+      Fs (native-add-seen-field exports Seen)
+      M infer-all MD P)
+  [[exports | Xs] | Fs] Seen M _ MD P
+  -> (native-parse-shen-scheme-extension
+      Fs (native-add-seen-field exports Seen)
+      M (native-exports Xs) MD P)
+  [[metadata | MD] | Fs] Seen M Xs _ P
+  -> (native-parse-shen-scheme-extension
+      Fs (native-add-seen-field metadata Seen)
+      M Xs (native-metadata-list MD) P)
+  [[profile P] | Fs] Seen M Xs MD _
+  -> (native-parse-shen-scheme-extension
+      Fs (native-add-seen-field profile Seen)
+      M Xs MD (native-compile-profile P))
+  [F | _] _ _ _ _ _
+  -> (error "shen/scheme extension has unknown or malformed field: ~S~%" F))
+
+(define native-module-extension-id
+  [module-extension Id _] -> Id)
+
+(define native-module-extension-ids
+  Es -> (map (function native-module-extension-id) Es))
+
+(define native-add-module-extension
+  [module-extension Id X] Es
+  -> (if (element? Id (native-module-extension-ids Es))
+         (error "module declaration has duplicate extension: ~A~%" Id)
+         [[module-extension Id X] | Es]))
+
+(define native-default-shen-scheme-extension
+  -> [module-extension shen/scheme
+      [shen-scheme-extension compatible infer-all
+       [runtime compiletime] release]])
+
+(define native-finalize-module-extensions
+  Es -> Es where (element? shen/scheme (native-module-extension-ids Es))
+  Es -> (append Es [(native-default-shen-scheme-extension)]))
+
+(define native-module-source-mode
+  [module-source M _] -> M)
+
+(define native-module-source-path
+  [module-source _ P] -> P)
 
 (define native-module-declaration-name
-  [module-declaration N _ _ _ _ _ _] -> N)
+  [module-declaration N _ _ _ _] -> N)
 
-(define native-module-declaration-mode
-  [module-declaration _ M _ _ _ _ _] -> M)
+(define native-module-declaration-source-specs
+  [module-declaration _ Ss _ _ _] -> Ss)
 
 (define native-module-declaration-sources
-  [module-declaration _ _ Ss _ _ _ _] -> Ss)
+  D -> (map (function native-module-source-path)
+            (native-module-declaration-source-specs D)))
+
+(define native-module-declaration-source-modes
+  D -> (map (function native-module-source-mode)
+            (native-module-declaration-source-specs D)))
 
 (define native-module-declaration-requires
-  [module-declaration _ _ _ Rs _ _ _] -> Rs)
+  [module-declaration _ _ Rs _ _] -> Rs)
+
+(define native-module-declaration-required-features
+  [module-declaration _ _ _ Fs _] -> Fs)
+
+(define native-module-declaration-extensions
+  [module-declaration _ _ _ _ Es] -> Es)
+
+(define native-module-extension
+  Id [[module-extension Id X] | _] -> X
+  Id [_ | Es] -> (native-module-extension Id Es)
+  _ [] -> (fail))
+
+(define native-module-declaration-extension
+  Id D -> (native-module-extension
+           Id (native-module-declaration-extensions D)))
+
+(define native-module-declaration-shen-scheme-extension
+  D -> (native-module-declaration-extension shen/scheme D))
+
+(define native-module-declaration-mode
+  D -> (native-shen-scheme-extension-mode
+        (native-module-declaration-shen-scheme-extension D)))
 
 (define native-module-declaration-exports
-  [module-declaration _ _ _ _ Xs _ _] -> Xs)
+  D -> (native-shen-scheme-extension-exports
+        (native-module-declaration-shen-scheme-extension D)))
 
 (define native-module-declaration-metadata
-  [module-declaration _ _ _ _ _ MD _] -> MD)
+  D -> (native-shen-scheme-extension-metadata
+        (native-module-declaration-shen-scheme-extension D)))
 
 (define native-module-declaration-profile
-  [module-declaration _ _ _ _ _ _ P] -> P)
+  D -> (native-shen-scheme-extension-profile
+        (native-module-declaration-shen-scheme-extension D)))
+
+(define native-shen-scheme-extension-mode
+  [shen-scheme-extension M _ _ _] -> M)
+
+(define native-shen-scheme-extension-exports
+  [shen-scheme-extension _ Xs _ _] -> Xs)
+
+(define native-shen-scheme-extension-metadata
+  [shen-scheme-extension _ _ MD _] -> MD)
+
+(define native-shen-scheme-extension-profile
+  [shen-scheme-extension _ _ _ P] -> P)
 
 (define native-module-declaration-key
-  [module-declaration N M Ss Rs Xs MD P]
-  -> ((foreign scm.shen-scheme-native-key) Ss [N M Rs Xs MD P]))
+  D -> ((foreign scm.shen-scheme-native-key)
+        (native-module-declaration-sources D)
+        [(native-module-declaration-name D)
+         (native-module-declaration-source-modes D)
+         (native-module-declaration-requires D)
+         (native-module-declaration-required-features D)
+         (native-module-declaration-mode D)
+         (native-module-declaration-exports D)
+         (native-module-declaration-metadata D)
+         (native-module-declaration-profile D)]))
 
 (define native-module-declaration-module-name
   D -> (intern (make-string "shen_native_decl_~A"
@@ -228,15 +363,20 @@
        (native-register-arities (native-exported-arities KL CXs))))
 
 (define native-prepare-module/declaration*
-  [module-declaration N M Ss Rs Xs _ _] Dir Stack L
-  -> (if (element? N Stack)
-         (native-cycle-error N)
-         (if (element? N L)
-             (do (native-prepare-module M Ss Xs) L)
-             (let L (native-prepare-module-requirements
-                      Rs Dir [N | Stack] L)
-               (do (native-prepare-module M Ss Xs)
-                   [N | L])))))
+  D Dir Stack L
+  -> (let N (native-module-declaration-name D)
+          M (native-module-declaration-mode D)
+          Ss (native-module-declaration-sources D)
+          Rs (native-module-declaration-requires D)
+          Xs (native-module-declaration-exports D)
+       (if (element? N Stack)
+           (native-cycle-error N)
+           (if (element? N L)
+               (do (native-prepare-module M Ss Xs) L)
+               (let L (native-prepare-module-requirements
+                        Rs Dir [N | Stack] L)
+                 (do (native-prepare-module M Ss Xs)
+                     [N | L]))))))
 
 (define native-load-module-requirements/with
   Ld Rd Rs Dir Stack L
@@ -266,17 +406,19 @@
 
 (define load-module/declaration*/with
   Ld Rd
-  [module-declaration M _ _ Rs _ _ _] Dir Stack L
-  -> (if (element? M Stack)
-         (native-cycle-error M)
-         (if (element? M L)
-             (let O (native-module-object-path Dir M)
-                  O (native-require-existing-file O "module object")
-               (do (Rd O) L))
-             (let L (native-load-module-requirements/with
-                      Ld Rd Rs Dir [M | Stack] L)
-                  O (native-module-object-path Dir M)
-                  O (native-require-existing-file O "module object")
-               (do (Ld O) [M | L])))))
+  D Dir Stack L
+  -> (let M (native-module-declaration-name D)
+          Rs (native-module-declaration-requires D)
+       (if (element? M Stack)
+           (native-cycle-error M)
+           (if (element? M L)
+               (let O (native-module-object-path Dir M)
+                    O (native-require-existing-file O "module object")
+                 (do (Rd O) L))
+               (let L (native-load-module-requirements/with
+                        Ld Rd Rs Dir [M | Stack] L)
+                    O (native-module-object-path Dir M)
+                    O (native-require-existing-file O "module object")
+                 (do (Ld O) [M | L]))))))
 
 )

--- a/src/native-modules.shen
+++ b/src/native-modules.shen
@@ -374,8 +374,7 @@
                    (freeze (set *property-vector* N))
                    (freeze
                     (do (native-register-arities As)
-                        (native-source-data->unit
-                         (native-process-module-sources Ss))))
+                        (native-process-module-sources Ss)))
                    (freeze (set *property-vector* O)))
              (do (native-record-package-forms (native-unit-packages U))
                  U)))

--- a/src/native-modules.shen
+++ b/src/native-modules.shen
@@ -9,6 +9,7 @@
   update-lambda-table
   scm.shen-scheme-native-key scm.shen-scheme-load-compiled
   scm.shen-scheme-load-compiled-for-compilation
+  scm.shen-scheme-resolve-module-source
   scm.file-exists? scm.dynamic-wind]
 
 (define native-single-form
@@ -18,8 +19,10 @@
                  P (length Fs)))
 
 (define native-read-module-declaration
-  P -> (native-parse-module-declaration
-        (native-single-form P (read-file-unprocessed P))))
+  P -> (native-resolve-module-declaration
+        P
+        (native-parse-module-declaration
+         (native-single-form P (read-file-unprocessed P)))))
 
 (define native-parse-module-declaration
   [shen.module | Fs] -> (native-parse-module-fields
@@ -189,6 +192,20 @@
 
 (define native-module-source-path
   [module-source _ P] -> P)
+
+(define native-resolve-module-source-path
+  D S -> ((foreign scm.shen-scheme-resolve-module-source) D S))
+
+(define native-resolve-module-source
+  D [module-source M S]
+  -> [module-source M (native-resolve-module-source-path D S)])
+
+(define native-resolve-module-declaration
+  D [module-declaration N Ss Rs Fs Es]
+  -> [module-declaration
+      N
+      (map (/. S (native-resolve-module-source D S)) Ss)
+      Rs Fs Es])
 
 (define native-module-declaration-name
   [module-declaration N _ _ _ _] -> N)

--- a/src/native-modules.shen
+++ b/src/native-modules.shen
@@ -10,6 +10,7 @@
   scm.shen-scheme-native-key scm.shen-scheme-load-compiled
   scm.shen-scheme-load-compiled-for-compilation
   scm.shen-scheme-resolve-module-source
+  scm.shen-scheme-relative-path?
   scm.file-exists? scm.dynamic-wind]
 
 (define native-single-form
@@ -88,6 +89,10 @@
 (define native-source-list
   Ss -> (native-source-list* Ss (fail) [] false))
 
+(define native-relative-source
+  S -> S where ((foreign scm.shen-scheme-relative-path?) S)
+  S -> (error "module declaration source must be relative, got: ~S~%" S))
+
 (define native-source-list*
   [] _ [] _ -> (error "module declaration requires at least one source~%")
   [] M _ true
@@ -103,7 +108,8 @@
   -> (error "module declaration source ~S must follow tc+ or tc-~%" S)
     where (= M (fail))
   [S | Ss] M Out _
-  -> (native-source-list* Ss M [[module-source M S] | Out] false)
+  -> (native-source-list*
+      Ss M [[module-source M (native-relative-source S)] | Out] false)
     where (string? S)
   [S | _] _ _ _
   -> (error "module declaration source must be a string, got: ~S~%" S))
@@ -310,6 +316,16 @@
   F _ -> F where ((foreign scm.file-exists?) F)
   F D -> (error "native module expected ~A to exist: ~A~%" D F))
 
+(define native-read-required-module-declaration
+  M Dir
+  -> (let P (native-module-declaration-path Dir M)
+          P (native-require-existing-file P "required module declaration")
+          D (native-read-module-declaration P)
+       (if (= M (native-module-declaration-name D))
+           D
+           (error "native module required ~A but ~A declares ~A~%"
+                  M P (native-module-declaration-name D)))))
+
 (define native-require-module-dir
   [] _ -> skip
   _ Dir -> (if (= Dir (fail))
@@ -333,9 +349,7 @@
 (define native-prepare-module-requirements*
   [] _ _ L -> L
   [R | Rs] Dir Stack L
-  -> (let P (native-module-declaration-path Dir R)
-          P (native-require-existing-file P "required module declaration")
-          D (native-read-module-declaration P)
+  -> (let D (native-read-required-module-declaration R Dir)
           L (native-prepare-module/declaration* D Dir Stack L)
        (native-prepare-module-requirements* Rs Dir Stack L)))
 
@@ -412,9 +426,7 @@
 (define native-load-module-requirements*/with
   _ _ [] _ _ L -> L
   Ld Rd [R | Rs] Dir Stack L
-  -> (let P (native-module-declaration-path Dir R)
-          P (native-require-existing-file P "required module declaration")
-          D (native-read-module-declaration P)
+  -> (let D (native-read-required-module-declaration R Dir)
           L (load-module/declaration*/with Ld Rd D Dir Stack L)
        (native-load-module-requirements*/with Ld Rd Rs Dir Stack L)))
 

--- a/src/native-modules.shen
+++ b/src/native-modules.shen
@@ -335,12 +335,6 @@
 (define native-cycle-error
   M -> (error "native module dependency cycle includes: ~A~%" M))
 
-(define native-load-module-requirements
-  Rs Dir Stack L -> (native-load-module-requirements/with
-                     (function load-compiled)
-                     (function native-load-compiled-for-compilation)
-                     Rs Dir Stack L))
-
 (define native-prepare-module-requirements
   Rs Dir Stack L
   -> (do (native-require-module-dir Rs Dir)
@@ -419,43 +413,50 @@
                      [N | L]))))))
 
 (define native-load-module-requirements/with
-  Ld Rd Rs Dir Stack L
-  -> (do (native-require-module-dir Rs Dir)
-         (native-load-module-requirements*/with Ld Rd Rs Dir Stack L)))
+  Ld Rd Rs ModuleDir ObjectDir Stack L
+  -> (do (native-require-module-dir Rs ModuleDir)
+         (native-load-module-requirements*/with
+          Ld Rd Rs ModuleDir ObjectDir Stack L)))
 
 (define native-load-module-requirements*/with
-  _ _ [] _ _ L -> L
-  Ld Rd [R | Rs] Dir Stack L
-  -> (let D (native-read-required-module-declaration R Dir)
-          L (load-module/declaration*/with Ld Rd D Dir Stack L)
-       (native-load-module-requirements*/with Ld Rd Rs Dir Stack L)))
+  _ _ [] _ _ _ L -> L
+  Ld Rd [R | Rs] ModuleDir ObjectDir Stack L
+  -> (let D (native-read-required-module-declaration R ModuleDir)
+          L (load-module/declaration*/with
+             Ld Rd D ModuleDir ObjectDir Stack L)
+       (native-load-module-requirements*/with
+        Ld Rd Rs ModuleDir ObjectDir Stack L)))
 
 (define load-module
-  F Dir -> (load-module/declaration (native-read-module-declaration F) Dir))
+  F ModuleDir ObjectDir
+  -> (load-module/declaration
+      (native-read-module-declaration F) ModuleDir ObjectDir))
 
 (define load-module/declaration
-  D Dir -> (load-module/declaration* D Dir [] []))
+  D ModuleDir ObjectDir
+  -> (load-module/declaration* D ModuleDir ObjectDir [] []))
 
 (define load-module/declaration*
-  D Dir Stack L -> (load-module/declaration*/with
-                    (function load-compiled)
-                    (function native-load-compiled-for-compilation)
-                    D Dir Stack L))
+  D ModuleDir ObjectDir Stack L
+  -> (load-module/declaration*/with
+      (function load-compiled)
+      (function native-load-compiled-for-compilation)
+      D ModuleDir ObjectDir Stack L))
 
 (define load-module/declaration*/with
   Ld Rd
-  D Dir Stack L
+  D ModuleDir ObjectDir Stack L
   -> (let M (native-module-declaration-name D)
           Rs (native-module-declaration-requires D)
        (if (element? M Stack)
            (native-cycle-error M)
            (if (element? M L)
-               (let O (native-module-object-path Dir M)
+               (let O (native-module-object-path ObjectDir M)
                     O (native-require-existing-file O "module object")
                  (do (Rd O) L))
                (let L (native-load-module-requirements/with
-                        Ld Rd Rs Dir [M | Stack] L)
-                    O (native-module-object-path Dir M)
+                        Ld Rd Rs ModuleDir ObjectDir [M | Stack] L)
+                    O (native-module-object-path ObjectDir M)
                     O (native-require-existing-file O "module object")
                  (do (Ld O) [M | L]))))))
 

--- a/src/native-source.shen
+++ b/src/native-source.shen
@@ -3,6 +3,7 @@
 
 (package shen-scheme
  [release debug wpo unsafe
+  tc+ tc-
   define defun defprolog declare defmacro datatype synonyms package
   native-unit runtime compiletime source-kl quote eval update-lambda-table
   _scm.prefix-op scm.dynamic-wind scm.hashtable-copy]
@@ -185,10 +186,103 @@
   [native-expanded Xs CTs Ps]
   -> (do (shen.find-arities Xs)
          (let Ts (shen.find-types Xs)
-           [native-source-data
-            (map (/. X (shen.process-applications X Ts)) Xs)
-            (mapcan (/. X X) CTs)
-            Ps])))
+              Fs (map (/. X (shen.process-applications X Ts)) Xs)
+           [native-source-data Fs (mapcan (/. X X) CTs) Ps
+            (native-type-table Fs)])))
+
+(define native-module-source-mode
+  [module-source M _] -> M)
+
+(define native-module-source-path
+  [module-source _ P] -> P)
+
+(define native-check-source-form
+  F T -> (let Check (shen.typecheck F T)
+           (if (= Check false)
+               (shen.type-error)
+               skip)))
+
+(define native-source-state-effect
+  [declare F T] -> (declare F T)
+  _ -> skip)
+
+(define native-check-source-forms
+  [] -> []
+  [F Colon T | Fs]
+  -> (do (native-check-source-form F T)
+         (native-source-state-effect F)
+         [F | (native-check-source-forms Fs)])
+    where (= Colon (intern ":"))
+  [F | Fs]
+  -> (do (native-check-source-form F (protect A))
+         (native-source-state-effect F)
+         [F | (native-check-source-forms Fs)]))
+
+(define native-source-state-effects
+  [] -> skip
+  [F Colon _ | Fs]
+  -> (do (native-source-state-effect F)
+         (native-source-state-effects Fs))
+    where (= Colon (intern ":"))
+  [F | Fs]
+  -> (do (native-source-state-effect F)
+         (native-source-state-effects Fs)))
+
+(define native-assumption-table->types
+  [] -> []
+  [F T | Ts] -> [[F T] | (native-assumption-table->types Ts)])
+
+(define native-check-module-source
+  tc+ Fs Table -> (do (shen.assumetypes Table)
+                      (native-check-source-forms Fs))
+  tc- Fs _ -> (do (native-source-state-effects Fs)
+                  Fs))
+
+(define native-source-data-forms
+  [native-source-data Fs _ _ _] -> Fs)
+
+(define native-source-data-compiletime
+  [native-source-data _ CT _ _] -> CT)
+
+(define native-source-data-packages
+  [native-source-data _ _ Ps _] -> Ps)
+
+(define native-process-module-source
+  [module-source M P]
+  -> (native-process-module-source*
+      M (native-expand-forms (read-file-unprocessed P))))
+
+(define native-process-module-source*
+  M [native-expanded Xs CTs Ps]
+  -> (do (shen.find-arities Xs)
+         (let Ts (shen.find-types Xs)
+              Fs (map (/. X (shen.process-applications X Ts)) Xs)
+              Table (if (= M tc+)
+                        (mapcan (/. F (shen.typetable F)) Fs)
+                        [])
+           (let RuntimeFs (native-check-module-source M Fs Table)
+             [native-source-data
+              RuntimeFs
+              (append
+              (native-type-declaration-forms
+               (native-assumption-table->types Table))
+               (mapcan (/. X X) CTs))
+              Ps
+              []]))))
+
+(define native-process-module-sources
+  [] -> [native-source-data [] [] [] []]
+  [S | Ss]
+  -> (let D (native-process-module-source S)
+          R (native-process-module-sources Ss)
+       [native-source-data
+            (append (native-source-data-forms D)
+                    (native-source-data-forms R))
+            (append (native-source-data-compiletime D)
+                    (native-source-data-compiletime R))
+            (append (native-source-data-packages D)
+                    (native-source-data-packages R))
+            []]))
 
 (define native-read-source
   S -> (native-read-sources [S]))
@@ -223,16 +317,19 @@
   [_ | Fs] -> (native-processed-inits Fs))
 
 (define native-forms->unit
-  Fs CT Ps -> (let All (native-processed-defines Fs)
+  Fs CT Ps Types -> (let All (native-processed-defines Fs)
                    Ds (native-last-defines All)
                    KL (map (function native-shen->kl) Ds)
                    Is (map (function native-init->kl) (native-processed-inits Fs))
-                   Ts (native-type-declaration-forms (native-type-table All))
+                   Ts (native-type-declaration-forms Types)
                 [native-unit KL Is (append Ts CT)
                  Ps]))
 
 (define native-unit-kl
   [native-unit KL _ _ _] -> KL)
+
+(define native-unit-packages
+  [native-unit _ _ _ Ps] -> Ps)
 
 (define native-arity-form
   [defun F As _] -> [(_scm.prefix-op update-lambda-table) [quote F] (length As)])
@@ -244,7 +341,14 @@
   Ss -> (with-native-compiler-state
          (freeze (native-source-data->unit (native-read-sources Ss)))))
 
+(define native-module-sources->unit
+  Ss -> (with-native-compiler-state
+         (freeze
+          (native-source-data->unit
+           (native-process-module-sources Ss)))))
+
 (define native-source-data->unit
-  [native-source-data Fs CT Ps] -> (native-forms->unit Fs CT Ps))
+  [native-source-data Fs CT Ps Types]
+  -> (native-forms->unit Fs CT Ps Types))
 
 )

--- a/src/native-source.shen
+++ b/src/native-source.shen
@@ -5,7 +5,9 @@
  [release debug wpo unsafe
   tc+ tc-
   define defun defprolog declare defmacro datatype synonyms package
-  native-unit runtime compiletime source-kl quote eval update-lambda-table
+  native-unit native-compiletime-group
+  runtime compiletime source-kl quote eval update-lambda-table
+  lambda fn
   _scm.prefix-op scm.dynamic-wind scm.hashtable-copy
   scm.read-file-as-bytelist]
 
@@ -25,6 +27,10 @@
             Datatypes (value shen.*datatypes*)
             AllDatatypes (value shen.*alldatatypes*)
             UserDefs (value shen.*userdefs*)
+            PatternHandlers
+            (value shen.x.programmable-pattern-matching.*pattern-handlers*)
+            PatternHandlerNames
+            (value shen.x.programmable-pattern-matching.*pattern-handlers-reg*)
          ((foreign scm.dynamic-wind)
           (freeze
            (do (set *property-vector* New)
@@ -39,7 +45,31 @@
                (set shen.*datatypes* Datatypes)
                (set shen.*alldatatypes* AllDatatypes)
                (set shen.*userdefs* UserDefs)
+               (set shen.x.programmable-pattern-matching.*pattern-handlers*
+                    PatternHandlers)
+               (set shen.x.programmable-pattern-matching.*pattern-handlers-reg*
+                    PatternHandlerNames)
                (set *native-compiler-state-depth* 0))))))
+
+(define native-register-pattern-handler
+  F _ -> F where (element?
+                   F
+                   (value shen.x.programmable-pattern-matching.*pattern-handlers-reg*))
+  F Handler
+  -> (do (set shen.x.programmable-pattern-matching.*pattern-handlers-reg*
+              [F | (value
+                    shen.x.programmable-pattern-matching.*pattern-handlers-reg*)])
+         (set shen.x.programmable-pattern-matching.*pattern-handlers*
+              [Handler | (value
+                          shen.x.programmable-pattern-matching.*pattern-handlers*)])
+         F))
+
+(define native-unregister-pattern-handler
+  F -> F where (not (element?
+                     F
+                     (value
+                      shen.x.programmable-pattern-matching.*pattern-handlers-reg*)))
+  F -> (shen.x.programmable-pattern-matching.unregister-handler F))
 
 (define native-scheme-path
   O -> (@s O ".scm"))
@@ -244,15 +274,6 @@
   tc- Fs _ -> (do (native-source-state-effects Fs)
                   Fs))
 
-(define native-source-data-forms
-  [native-source-data Fs _ _ _] -> Fs)
-
-(define native-source-data-compiletime
-  [native-source-data _ CT _ _] -> CT)
-
-(define native-source-data-packages
-  [native-source-data _ _ Ps _] -> Ps)
-
 (define native-process-module-source
   [module-source M P]
   -> (native-process-module-source*
@@ -276,29 +297,14 @@
               Ps
               []]))))
 
-(define native-process-module-sources
-  [] -> [native-source-data [] [] [] []]
-  [S | Ss]
-  -> (let D (native-process-module-source S)
-          R (native-process-module-sources Ss)
-       [native-source-data
-            (append (native-source-data-forms D)
-                    (native-source-data-forms R))
-            (append (native-source-data-compiletime D)
-                    (native-source-data-compiletime R))
-            (append (native-source-data-packages D)
-                    (native-source-data-packages R))
-            []]))
-
-(define native-read-source
-  S -> (native-read-sources [S]))
-
 (define native-read-sources
-  Ss -> (native-process-expanded (native-expand-forms (native-read-source-forms Ss))))
+  Ss -> (native-process-expanded
+         (native-expand-forms (native-read-source-forms Ss))))
 
 (define native-read-source-forms
   [] -> []
-  [S | Ss] -> (append (read-file-unprocessed S) (native-read-source-forms Ss)))
+  [S | Ss] -> (append (read-file-unprocessed S)
+                      (native-read-source-forms Ss)))
 
 (define native-processed-defines
   [] -> []
@@ -322,14 +328,96 @@
   [[F | Rs] | Fs] -> [[F | Rs] | (native-processed-inits Fs)]
   [_ | Fs] -> (native-processed-inits Fs))
 
+(define native-record-defun
+  [defun F | X] -> (put F shen-scheme.native-defun [defun F | X]))
+
+(define native-record-defuns
+  [] -> skip
+  [D | KL] -> (do (native-record-defun D)
+                  (native-record-defuns KL)))
+
+(define native-defun-lambda
+  [defun _ As B] -> (native-args-lambda As B))
+
+(define native-args-lambda
+  [] _ -> (error "native pattern handler must take at least one argument~%")
+  [A] B -> [lambda A B]
+  [A | As] B -> [lambda A (native-args-lambda As B)])
+
+(define native-pattern-handler-lambda
+  F -> (trap-error
+        (native-defun-lambda (get F shen-scheme.native-defun))
+        (/. X [fn F])))
+
+(define native-pattern-effect-kl
+  [shen.x.programmable-pattern-matching.register-handler F]
+  -> [shen-scheme.native-register-pattern-handler
+      F
+      (native-pattern-handler-lambda F)]
+  [shen.x.programmable-pattern-matching.unregister-handler F]
+  -> [shen-scheme.native-unregister-pattern-handler F]
+  _ -> [])
+
+(define native-init-form->kl
+  F -> (let E (native-pattern-effect-kl F)
+         (if (= E []) (native-init->kl F) E)))
+
+(define native-processed-init-kl
+  Fs -> (map (function native-init-form->kl) (native-processed-inits Fs)))
+
+(define native-pattern-effect-kl-forms
+  [] -> []
+  [F | Fs] -> (let E (native-pattern-effect-kl F)
+                (if (= E [])
+                    (native-pattern-effect-kl-forms Fs)
+                    [E | (native-pattern-effect-kl-forms Fs)])))
+
+(define native-stage-pattern-effect
+  [shen-scheme.native-unregister-pattern-handler F]
+  -> (native-unregister-pattern-handler F)
+  E -> (eval-kl E))
+
+(define native-stage-pattern-effects
+  [] -> skip
+  [E | Es] -> (do (native-stage-pattern-effect E)
+                  (native-stage-pattern-effects Es)))
+
 (define native-forms->unit
   Fs CT Ps Types -> (let All (native-processed-defines Fs)
-                   Ds (native-last-defines All)
-                   KL (map (function native-shen->kl) Ds)
-                   Is (map (function native-init->kl) (native-processed-inits Fs))
-                   Ts (native-type-declaration-forms Types)
-                [native-unit KL Is (append Ts CT)
-                 Ps]))
+                         Ds (native-last-defines All)
+                         KL (map (function native-shen->kl) Ds)
+                      (do (native-record-defuns KL)
+                          (let Is (native-processed-init-kl Fs)
+                               Es (native-pattern-effect-kl-forms Fs)
+                               Ts (native-type-declaration-forms Types)
+                            (do (native-stage-pattern-effects Es)
+                                [native-unit KL Is
+                                 [[native-compiletime-group
+                                   (append Ts CT) Es]]
+                                 Ps])))))
+
+(define native-empty-unit
+  -> [native-unit [] [] [] []])
+
+(define native-append-units
+  [native-unit KL1 Is1 CT1 Ps1]
+  [native-unit KL2 Is2 CT2 Ps2]
+  -> [native-unit (append KL1 KL2) (append Is1 Is2)
+      (append CT1 CT2) (append Ps1 Ps2)])
+
+(define native-last-defuns
+  KL -> (reverse (native-last-defuns* (reverse KL) [])))
+
+(define native-last-defuns*
+  [] _ -> []
+  [[defun F _ _] | KL] Seen -> (native-last-defuns* KL Seen)
+    where (element? F Seen)
+  [[defun F As B] | KL] Seen
+  -> [[defun F As B] | (native-last-defuns* KL [F | Seen])])
+
+(define native-finalize-unit
+  [native-unit KL Is CT Ps]
+  -> [native-unit (native-last-defuns KL) Is CT Ps])
 
 (define native-unit-kl
   [native-unit KL _ _ _] -> KL)
@@ -349,9 +437,17 @@
 
 (define native-module-sources->unit
   Ss -> (with-native-compiler-state
-         (freeze
-          (native-source-data->unit
-           (native-process-module-sources Ss)))))
+         (freeze (native-process-module-sources Ss))))
+
+(define native-process-module-sources
+  Ss -> (native-finalize-unit (native-process-module-sources* Ss)))
+
+(define native-process-module-sources*
+  [] -> (native-empty-unit)
+  [S | Ss]
+  -> (let U (native-source-data->unit (native-process-module-source S))
+          Us (native-process-module-sources* Ss)
+       (native-append-units U Us)))
 
 (define native-source-data->unit
   [native-source-data Fs CT Ps Types]

--- a/src/native-source.shen
+++ b/src/native-source.shen
@@ -6,7 +6,8 @@
   tc+ tc-
   define defun defprolog declare defmacro datatype synonyms package
   native-unit runtime compiletime source-kl quote eval update-lambda-table
-  _scm.prefix-op scm.dynamic-wind scm.hashtable-copy]
+  _scm.prefix-op scm.dynamic-wind scm.hashtable-copy
+  scm.read-file-as-bytelist]
 
 (set *native-compiler-state-depth* 0)
 
@@ -71,10 +72,15 @@
   [_ _ _ _ WPO] _ -> WPO)
 
 (define read-file-unprocessed
-  F -> (let Bs (read-file-as-bytelist F)
-            Fs (trap-error (compile (/. X (shen.<s-exprs> X)) Bs)
-                           (/. E (shen.reader-error (value shen.*residue*))))
-         Fs))
+  F -> (read-bytelist-unprocessed (read-file-as-bytelist F)))
+
+(define native-read-file-unprocessed
+  F -> (read-bytelist-unprocessed
+        ((foreign scm.read-file-as-bytelist) F)))
+
+(define read-bytelist-unprocessed
+  Bs -> (trap-error (compile (/. X (shen.<s-exprs> X)) Bs)
+                    (/. X (shen.reader-error (value shen.*residue*)))))
 
 (define native-shen->kl
   [define F | _] -> (error "~A is not a legitimate function name~%" F)
@@ -250,7 +256,7 @@
 (define native-process-module-source
   [module-source M P]
   -> (native-process-module-source*
-      M (native-expand-forms (read-file-unprocessed P))))
+      M (native-expand-forms (native-read-file-unprocessed P))))
 
 (define native-process-module-source*
   M [native-expanded Xs CTs Ps]

--- a/src/primitives.scm
+++ b/src/primitives.scm
@@ -285,6 +285,10 @@
       source
       (path-build (path-parent (full-path-for-file declaration)) source)))
 
+(define (shen-scheme-relative-path? path)
+  (and (> (string-length path) 0)
+       (not (path-absolute? path))))
+
 (define (shen-scheme-native-key sources options)
   (shen-scheme-hash->hex
    (shen-scheme-hash-string

--- a/src/primitives.scm
+++ b/src/primitives.scm
@@ -280,6 +280,11 @@
 (define (shen-scheme-native-source-key source)
   (list (full-path-for-file source) (shen-scheme-file-hash source)))
 
+(define (shen-scheme-resolve-module-source declaration source)
+  (if (path-absolute? source)
+      source
+      (path-build (path-parent (full-path-for-file declaration)) source)))
+
 (define (shen-scheme-native-key sources options)
   (shen-scheme-hash->hex
    (shen-scheme-hash-string

--- a/src/primitives.scm
+++ b/src/primitives.scm
@@ -283,7 +283,9 @@
 (define (shen-scheme-resolve-module-source declaration source)
   (if (path-absolute? source)
       source
-      (path-build (path-parent (full-path-for-file declaration)) source)))
+      (path-build
+       (path-parent (full-path-for-file (with-home-directory declaration)))
+       source)))
 
 (define (shen-scheme-relative-path? path)
   (and (> (string-length path) 0)

--- a/src/shen-scheme-extensions.shen
+++ b/src/shen-scheme-extensions.shen
@@ -80,12 +80,13 @@ build-module-app.
 Compiles a portable shen.module version 1 declaration to a Chez object file.
 
 The declaration file is parsed as raw Shen data without macro expansion. The
-The portable core supports ordered source lists, feature requirements, and
+portable core supports ordered source lists, feature requirements, and
 static dependencies. Shen/Scheme compilation settings live in the shen/scheme
 extension. Standalone module compilation requires sealed mode for explicit
 exports. With --module-dir, symbolic requires are resolved as
 <DIR>/<module-name>.shenmod and analyzed from source without loading their
 compiled objects, installing ordinary definitions, or running initializers.
+Relative source paths are resolved from the declaration file's directory.
 Dependency macros must be self-contained or use helpers already loaded in the
 compiler, and their transformer names must not collide with live bindings.
 Foreign Scheme definition-context forms are not supported as native

--- a/src/shen-scheme-extensions.shen
+++ b/src/shen-scheme-extensions.shen
@@ -86,7 +86,8 @@ extension. Standalone module compilation requires sealed mode for explicit
 exports. With --module-dir, symbolic requires are resolved as
 <DIR>/<module-name>.shenmod and analyzed from source without loading their
 compiled objects, installing ordinary definitions, or running initializers.
-Relative source paths are resolved from the declaration file's directory.
+Source paths must be relative and are resolved from the declaration file's
+directory.
 Sources following tc+ are typechecked; sources following tc- are not. The mode
 continues until the next marker in the ordered source list.
 Dependency macros must be self-contained or use helpers already loaded in the

--- a/src/shen-scheme-extensions.shen
+++ b/src/shen-scheme-extensions.shen
@@ -36,8 +36,9 @@ corruption. Use only for trusted, well-tested code.
     compile-module <DECLARATION> -o <OBJECT> [--emit-scheme <SCHEME>] [--module-dir <DIR>]
         Compiles a Shen-readable native module declaration to a Chez object file.
 
-    load-module <DECLARATION> --module-dir <DIR>
-        Loads a compiled native module and its required modules from DIR.
+    load-module <DECLARATION> --module-dir <DIR> --object-dir <DIR>
+        Loads declarations from the module directory and compiled objects from
+        the object directory.
 
     build-app <MAIN> [--module <SOURCE> ...] -o <OBJECT> [--wpo] [--profile release|debug|wpo|unsafe]
         Builds a Shen application object from generated Chez libraries.
@@ -98,11 +99,11 @@ initializers.
 
 (define shen-scheme.load-module-help-text
   Exe -> (@s "Usage: " Exe
-             " load-module <DECLARATION> --module-dir <DIR>
+             " load-module <DECLARATION> --module-dir <DIR> --object-dir <DIR>
 
-Loads a compiled native module and its transitive required modules from DIR.
-Module names resolve as <DIR>/<module-name>.shenmod and
-<DIR>/<module-name>.so.
+Loads a compiled native module and its transitive required modules.
+Module names resolve as <module-dir>/<module-name>.shenmod and
+<object-dir>/<module-name>.so.
 "))
 
 (define shen-scheme.build-app-help-text
@@ -222,12 +223,39 @@ initializers.
   Exe Args -> (shen-scheme.compile-module-command*
                Exe (shen-scheme.parse-compile-module-args Args)))
 
-(define shen-scheme.load-module-command
-  Exe ["--help"] -> [show-help (shen-scheme.load-module-help-text Exe)]
-  _ [Declaration "--module-dir" ModuleDir]
-  -> (do (shen-scheme.load-module Declaration ModuleDir)
+(define shen-scheme.parse-load-module-args
+  [Declaration | Args]
+  -> (shen-scheme.parse-load-module-options
+      Args Declaration (fail) (fail))
+  _ -> [error])
+
+(define shen-scheme.parse-load-module-options
+  [] Declaration ModuleDir ObjectDir
+  -> [ok Declaration ModuleDir ObjectDir]
+  ["--module-dir" ModuleDir | Rest] Declaration _ ObjectDir
+  -> (shen-scheme.parse-load-module-options
+      Rest Declaration ModuleDir ObjectDir)
+  ["--object-dir" ObjectDir | Rest] Declaration ModuleDir _
+  -> (shen-scheme.parse-load-module-options
+      Rest Declaration ModuleDir ObjectDir)
+  [Arg | _] _ _ _ -> [error Arg])
+
+(define shen-scheme.load-module-command*
+  Exe [ok _ ModuleDir _]
+  -> [error (shen-scheme.load-module-help-text Exe)]
+    where (= ModuleDir (fail))
+  Exe [ok _ _ ObjectDir]
+  -> [error (shen-scheme.load-module-help-text Exe)]
+    where (= ObjectDir (fail))
+  _ [ok Declaration ModuleDir ObjectDir]
+  -> (do (shen-scheme.load-module Declaration ModuleDir ObjectDir)
          [success])
   Exe _ -> [error (shen-scheme.load-module-help-text Exe)])
+
+(define shen-scheme.load-module-command
+  Exe ["--help"] -> [show-help (shen-scheme.load-module-help-text Exe)]
+  Exe Args -> (shen-scheme.load-module-command*
+               Exe (shen-scheme.parse-load-module-args Args)))
 
 (define shen-scheme.parse-build-app-args
   [] Modules Object Wpo Profile -> [ok (reverse Modules) Object Wpo Profile]

--- a/src/shen-scheme-extensions.shen
+++ b/src/shen-scheme-extensions.shen
@@ -87,6 +87,8 @@ exports. With --module-dir, symbolic requires are resolved as
 <DIR>/<module-name>.shenmod and analyzed from source without loading their
 compiled objects, installing ordinary definitions, or running initializers.
 Relative source paths are resolved from the declaration file's directory.
+Sources following tc+ are typechecked; sources following tc- are not. The mode
+continues until the next marker in the ordered source list.
 Dependency macros must be self-contained or use helpers already loaded in the
 compiler, and their transformer names must not collide with live bindings.
 Foreign Scheme definition-context forms are not supported as native

--- a/src/shen-scheme-extensions.shen
+++ b/src/shen-scheme-extensions.shen
@@ -77,11 +77,12 @@ build-module-app.
   Exe -> (@s "Usage: " Exe
              " compile-module <DECLARATION> -o <OBJECT> [--emit-scheme <SCHEME>] [--module-dir <DIR>]
 
-Compiles a Shen-readable native module declaration to a Chez object file.
+Compiles a portable shen.module version 1 declaration to a Chez object file.
 
 The declaration file is parsed as raw Shen data without macro expansion. The
-module declaration compiler supports explicit source lists and static
-dependencies. Standalone module compilation requires sealed mode for explicit
+The portable core supports ordered source lists, feature requirements, and
+static dependencies. Shen/Scheme compilation settings live in the shen/scheme
+extension. Standalone module compilation requires sealed mode for explicit
 exports. With --module-dir, symbolic requires are resolved as
 <DIR>/<module-name>.shenmod and analyzed from source without loading their
 compiled objects, installing ordinary definitions, or running initializers.

--- a/tests/native/package-effects.shenmod
+++ b/tests/native/package-effects.shenmod
@@ -1,6 +1,8 @@
-(shen.aot.module
+(shen.module
+  (version 1)
   (name native.test.package-effects)
-  (mode sealed)
-  (exports)
-  (metadata)
-  (sources "tests/native/package-effects.shen"))
+  (sources tc- "tests/native/package-effects.shen")
+  (extension shen/scheme
+    (mode sealed)
+    (exports)
+    (metadata)))

--- a/tests/native/package-effects.shenmod
+++ b/tests/native/package-effects.shenmod
@@ -1,7 +1,7 @@
 (shen.module
   (version 1)
   (name native.test.package-effects)
-  (sources tc- "tests/native/package-effects.shen")
+  (sources tc- "package-effects.shen")
   (extension shen/scheme
     (mode sealed)
     (exports)

--- a/tests/programmable-pattern-matching/after-unregister.shen
+++ b/tests/programmable-pattern-matching/after-unregister.shen
@@ -1,0 +1,3 @@
+(define ppm-test.match-after-unregister
+  [ppm-test.two A B] -> [A B]
+  _ -> no)

--- a/tests/programmable-pattern-matching/code.shen
+++ b/tests/programmable-pattern-matching/code.shen
@@ -1,0 +1,15 @@
+(define ppm-test.match-simple
+  [ppm-test.two A B] -> [A B]
+  _ -> no)
+
+(define ppm-test.match-repeat
+  [ppm-test.two X X] -> same
+  [ppm-test.two _ _] -> different)
+
+(define ppm-test.match-nested
+  [ppm-test.two [ppm-test.two A B] C] -> [A B C]
+  _ -> no)
+
+(define ppm-test.match-cons
+  [H | T] -> [H T]
+  _ -> no)


### PR DESCRIPTION
## Summary

### Portable Shen modules

- replace the Shen/Scheme-specific module declaration with a versioned portable `shen.module` format
- add portable dependency, feature, and per-source typechecking metadata while keeping native settings in a namespaced `shen/scheme` extension
- resolve module sources relative to their descriptors, validate required-module identities, and separate declaration and compiled-object roots
- preserve source-order type and compiler state during native module and module-app compilation
- migrate the tracked descriptors, examples, command-line interface, documentation, and regression tests

### Programmable pattern matching

- enable Shen's programmable-pattern-matching extension in the generated Shen/Scheme runtime
- initialize the extension at startup so libraries can register custom pattern handlers without loading the extension separately
- cover registration, repeated and nested custom patterns, built-in patterns, and unregistration under both Chez and Petite

## Motivation

The previous `.shenmod` format mixed portable module metadata with Shen/Scheme AOT settings and resolved source paths from the process working directory. That made it unsuitable as a shared module format for Shen libraries and made module builds sensitive to where the compiler was invoked.

This change defines a small portable core while allowing ports to retain namespaced extensions. Shen/Scheme continues to own only its native compilation settings.

Programmable pattern matching is also required by Shen libraries that define custom patterns. The extension was present in the Shen kernel but was not included or initialized in the generated Shen/Scheme runtime; this change enables it as a runtime capability.

## User impact

This is a breaking change to the unreleased module format and loading API:

- descriptors now use `shen.module` with `(version 1)`
- source entries require explicit `tc+` or `tc-` markers and relative paths
- `load-module` receives separate module and object roots
- Shen/Scheme-specific compilation fields live under `(extension shen/scheme ...)`

Programmable pattern handlers can now be registered and used without manually loading or initializing the extension.

## Validation

- `make test`
- native module compile/load and module-app regression suites
- programmable-pattern-matching tests under default Chez and Petite runtimes
- descriptor-relative source resolution under a nonempty Shen `*home-directory*`
